### PR TITLE
APB-5895

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -33,4 +33,5 @@ class AppConfig @Inject()(servicesConfig: ServicesConfig) {
   val agentServicesAccountManageAccountPath: String = servicesConfig.getString("microservice.services.agent-services-account-frontend.manage-account-path")
   val agentServicesAccountManageAccountUrl = agentServicesAccountExternalUrl + agentServicesAccountManageAccountPath
   val agentPermissionsBaseUrl: String = servicesConfig.baseUrl("agent-permissions")
+  val agentUserClientDetailsBaseUrl: String = servicesConfig.baseUrl("agent-user-client-details")
 }

--- a/app/connectors/AgentPermissionsConnector.scala
+++ b/app/connectors/AgentPermissionsConnector.scala
@@ -66,7 +66,7 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)
       http.POSTEmpty[HttpResponse](url).map{ response =>
         response.status match {
           case ACCEPTED => Done
-          case e => throw UpstreamErrorResponse(s"error sending optin request",e)
+          case e => throw UpstreamErrorResponse(s"error sending optin request for ${arn.value}",e)
         }
       }
     }

--- a/app/connectors/AgentPermissionsConnector.scala
+++ b/app/connectors/AgentPermissionsConnector.scala
@@ -22,7 +22,7 @@ import com.google.inject.ImplementedBy
 import com.kenshoo.play.metrics.Metrics
 import config.AppConfig
 import play.api.Logging
-import play.api.http.Status.{ACCEPTED, OK}
+import play.api.http.Status.{ACCEPTED, CREATED, OK}
 import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, OptinStatus}
 import uk.gov.hmrc.http.HttpReads.Implicits.readRaw
@@ -66,7 +66,7 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)
     monitor("ConsumedAPI-optin-POST"){
       http.POSTEmpty[HttpResponse](url).map{ response =>
         response.status match {
-          case ACCEPTED => Done
+          case CREATED => Done
           case e => throw UpstreamErrorResponse(s"error sending optin request for ${arn.value}",e)
         }
       }

--- a/app/connectors/AgentUserClientDetailsConnector.scala
+++ b/app/connectors/AgentUserClientDetailsConnector.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.codahale.metrics.MetricRegistry
+import com.google.inject.ImplementedBy
+import com.kenshoo.play.metrics.Metrics
+import config.AppConfig
+import play.api.Logging
+import play.api.http.Status.{ACCEPTED, OK}
+import uk.gov.hmrc.agent.kenshoo.monitoring.HttpAPIMonitor
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Enrolment}
+import uk.gov.hmrc.http.{HeaderCarrier, HttpClient, HttpResponse, UpstreamErrorResponse}
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.util.Try
+
+@ImplementedBy(classOf[AgentUserClientDetailsConnectorImpl])
+trait AgentUserClientDetailsConnector extends HttpAPIMonitor with Logging {
+  val http: HttpClient
+
+  def getClientList(arn: Arn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Seq[Enrolment]]]
+
+}
+
+@Singleton
+class AgentUserClientDetailsConnectorImpl @Inject()(val http: HttpClient)(implicit metrics: Metrics, appConfig: AppConfig) extends AgentUserClientDetailsConnector with HttpAPIMonitor with Logging {
+
+  override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
+
+  private val baseUrl = appConfig.agentPermissionsBaseUrl
+
+  def getClientList(arn: Arn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Seq[Enrolment]]] = {
+    val url = s"$baseUrl/agent-user-client-details/arn/${arn.value}/client-list"
+    monitor("ConsumedAPI-getClientList-GET") {
+      http.GET[HttpResponse](url).map{
+        response => response.status match {
+          case ACCEPTED   => None
+          case OK         =>  response.json.asOpt[Seq[Enrolment]]
+          case e          => throw UpstreamErrorResponse(s"error getClientList for ${arn.value}",e)
+        }
+      }
+    }
+  }
+}

--- a/app/connectors/AgentUserClientDetailsConnector.scala
+++ b/app/connectors/AgentUserClientDetailsConnector.scala
@@ -43,7 +43,7 @@ class AgentUserClientDetailsConnectorImpl @Inject()(val http: HttpClient)(implic
 
   override val kenshooRegistry: MetricRegistry = metrics.defaultRegistry
 
-  private val baseUrl = appConfig.agentPermissionsBaseUrl
+  private val baseUrl = appConfig.agentUserClientDetailsBaseUrl
 
   def getClientList(arn: Arn)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[Seq[Enrolment]]] = {
     val url = s"$baseUrl/agent-user-client-details/arn/${arn.value}/client-list"

--- a/app/controllers/GroupsController.scala
+++ b/app/controllers/GroupsController.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import connectors.{AgentPermissionsConnector, AgentUserClientDetailsConnector}
+import play.api.i18n.{I18nSupport, MessagesApi}
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import repository.SessionCacheRepository
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.ExecutionContext
+
+@Singleton
+class GroupsController @Inject()(
+                                  authAction: AuthAction,
+                                  mcc: MessagesControllerComponents,
+                                  val agentPermissionsConnector: AgentPermissionsConnector,
+                                  val sessionCacheRepository: SessionCacheRepository)(implicit val appConfig: AppConfig, ec: ExecutionContext, implicit override val messagesApi: MessagesApi)
+  extends FrontendController(mcc) with I18nSupport with SessionBehaviour {
+
+  import authAction._
+
+  def root: Action[AnyContent] = Action { implicit request =>
+    Ok("groups")
+  }
+
+}

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+import models.JourneySession
+import uk.gov.hmrc.mongo.cache.DataKey
+
 import scala.concurrent.Future
 
 package object controllers {
@@ -21,4 +24,6 @@ package object controllers {
   implicit class ToFuture[T](t: T) {
     def toFuture = Future successful t
   }
+
+  val DATA_KEY: DataKey[JourneySession] = DataKey("journey")
 }

--- a/app/models/JourneySession.scala
+++ b/app/models/JourneySession.scala
@@ -17,9 +17,11 @@
 package models
 
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.agentmtdidentifiers.model.{OptedInNotReady, OptedInReady, OptedInSingleUser, OptedOutEligible, OptinStatus}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Enrolment, OptedInNotReady, OptedInReady, OptedInSingleUser, OptedOutEligible, OptinStatus}
 
-case class JourneySession(optinStatus: OptinStatus){
+case class JourneySession(
+                           optinStatus: OptinStatus,
+                           clientList: Option[Seq[Enrolment]] = None){
 
   val isEligibleToOptIn = optinStatus == OptedOutEligible
   val isEligibleToOptOut = optinStatus == OptedInReady || optinStatus == OptedInNotReady || optinStatus == OptedInSingleUser

--- a/app/services/OptInService.scala
+++ b/app/services/OptInService.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import akka.Done
+import connectors.{AgentPermissionsConnector, AgentUserClientDetailsConnector}
+import controllers.DATA_KEY
+import models.JourneySession
+import play.api.mvc.Request
+import repository.SessionCacheRepository
+import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class OptInService @Inject()(
+                              agentPermissionsConnector: AgentPermissionsConnector,
+                              agentUserClientDetailsConnector: AgentUserClientDetailsConnector,
+                              sessionCacheRepository: SessionCacheRepository
+                            ) {
+
+
+  def processOptIn(arn: Arn)(implicit request: Request[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Done] = {
+    for {
+      _ <- agentPermissionsConnector.optin(arn)
+      maybeClientList <- agentUserClientDetailsConnector.getClientList(arn)
+      status <- agentPermissionsConnector.getOptinStatus(arn)
+      _ <- sessionCacheRepository
+        .putSession(
+          DATA_KEY,
+          JourneySession(
+            optinStatus = status.getOrElse(throw new RuntimeException("could not complete opt-in process as opt-in status was unavailable")),
+            clientList = maybeClientList)
+        )
+    } yield Done
+  }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -12,3 +12,5 @@ POST       /opt-in/do-you-want-to-opt-in    controllers.OptInController.submitDo
 
 GET        /opt-in/you-have-opted-in        controllers.OptInController.showYouHaveOptedIn
 GET        /opt-in/you-have-not-opted-in       controllers.OptInController.showYouHaveNotOptedIn
+
+GET        /groups                          controllers.GroupsController.root

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -86,6 +86,12 @@ microservice {
       host = localhost
       port = 9447
     }
+    agent-user-client-details {
+      protocol = http
+      host = localhost
+      port = 9449
+    }
+
   }
 
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -9,7 +9,7 @@ object AppDependencies {
     "uk.gov.hmrc"             %% "bootstrap-frontend-play-28" % "5.24.0",
     "uk.gov.hmrc"             %% "play-frontend-hmrc"         % "3.15.0-play-28",
     "uk.gov.hmrc.mongo"       %% "hmrc-mongo-play-28"         % "0.63.0",
-    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.36.0-play-28",
+    "uk.gov.hmrc"             %% "agent-mtd-identifiers"      % "0.37.0-play-28",
     "uk.gov.hmrc"             %% "agent-kenshoo-monitoring"   % "4.8.0-play-28",
   )
 

--- a/test/connectors/AgentPermissionsConnectorSpec.scala
+++ b/test/connectors/AgentPermissionsConnectorSpec.scala
@@ -57,7 +57,7 @@ class AgentPermissionsConnectorSpec extends BaseISpec with HttpClientMocks with 
   "postOptin" should {
     "return Done when successful" in {
 
-      mockHttpPost[HttpResponse](HttpResponse.apply(202, ""))
+      mockHttpPost[HttpResponse](HttpResponse.apply(201, ""))
       connector.optin(arn).futureValue shouldBe Done
     }
     "throw an exception when there was a problem" in {

--- a/test/connectors/AgentUserClientDetailsConnectorSpec.scala
+++ b/test/connectors/AgentUserClientDetailsConnectorSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package connectors
+
+import com.google.inject.AbstractModule
+import helpers.{AgentUserClientDetailsConnectorMocks, BaseISpec, HttpClientMocks}
+import play.api.Application
+import play.api.http.Status.{ACCEPTED, OK}
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import uk.gov.hmrc.agentmtdidentifiers.model.{Enrolment, Identifier}
+import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
+
+class AgentUserClientDetailsConnectorSpec extends BaseISpec with HttpClientMocks with AgentUserClientDetailsConnectorMocks {
+
+  implicit val mockHttpClient: HttpClient = mock[HttpClient]
+
+  override def moduleWithOverrides: AbstractModule = new AbstractModule() {
+
+    override def configure(): Unit = {
+      bind(classOf[HttpClient]).toInstance(mockHttpClient)
+    }
+  }
+
+  override implicit lazy val fakeApplication: Application =
+    appBuilder
+      .build()
+
+  val connector: AgentUserClientDetailsConnector = fakeApplication.injector.instanceOf[AgentUserClientDetailsConnectorImpl]
+
+  "getClientList" should {
+    "return a Some[Seq[Enrolment]] when status response is OK" in {
+      mockHttpGet[HttpResponse](HttpResponse.apply(OK,
+      """[
+          |{
+          |"service": "HMRC-MTD-IT",
+          |"state": "Active",
+          |"friendlyName": "Rapunzel",
+          |"identifiers": [{
+          |"key": "MTDITID",
+          |"value": "XX12345"
+          |}]
+          |}]""".stripMargin
+      )
+      )
+
+      connector.getClientList(arn).futureValue shouldBe Some(
+        Seq(
+        Enrolment(
+          service = "HMRC-MTD-IT",
+          state = "Active",
+          friendlyName = "Rapunzel",
+          identifiers = List(Identifier(key = "MTDITID", value = "XX12345")))))
+    }
+
+    "return None when status response is Accepted" in {
+
+      mockHttpGet[HttpResponse](HttpResponse.apply(ACCEPTED,""))
+
+      connector.getClientList(arn).futureValue shouldBe None
+    }
+
+    "throw error when status reponse is 5xx" in {
+
+      mockHttpGet[HttpResponse](HttpResponse.apply(503,""))
+
+      intercept[UpstreamErrorResponse]{
+        await(connector.getClientList(arn))
+      }
+    }
+  }
+
+}

--- a/test/controllers/GroupsControllerSpec.scala
+++ b/test/controllers/GroupsControllerSpec.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,19 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import config.AppConfig
-@import views.html.main_layout
+package controllers
 
-@this(layout: main_layout, p: p, h1: h1, h2: h2, link_as_button: link_as_button)
+class GroupsControllerSpec {
 
-@(continueUrl: String)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
-
-@layout(
-    title = msgs("you-have-opted-in.h1", msgs("service.name"))) {
-    @h1("you-have-opted-in.h1")
-    @h2("you-have-opted-in.h2")
-    @p("you-have-opted-in.p")
-    @link_as_button(messageKey = "you-have-opted-in.button", href = continueUrl)
 }

--- a/test/controllers/OptInControllerSpec.scala
+++ b/test/controllers/OptInControllerSpec.scala
@@ -99,13 +99,14 @@ class OptInControllerSpec extends BaseISpec {
       status(result) shouldBe FORBIDDEN
     }
 
-    "return Forbidden when user is not eligible" in {
+    "redirect user to root when user is not eligible" in {
 
       stubAuthorisationGrantAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedOutSingleUser)
 
       val result = controller.start()(request)
-      status(result) shouldBe FORBIDDEN
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result).get shouldBe routes.RootController.start.url
     }
   }
 

--- a/test/controllers/RootControllerSpec.scala
+++ b/test/controllers/RootControllerSpec.scala
@@ -16,24 +16,99 @@
 
 package controllers
 
+import com.google.inject.AbstractModule
+import connectors.{AgentPermissionsConnector, AgentUserClientDetailsConnector}
 import helpers.BaseISpec
+import models.JourneySession
 import play.api.Application
 import play.api.http.Status.SEE_OTHER
 import play.api.test.Helpers._
+import repository.SessionCacheRepository
+import uk.gov.hmrc.agentmtdidentifiers.model.{OptedInReady, OptedOutEligible, OptedOutSingleUser}
+import uk.gov.hmrc.auth.core.AuthConnector
+import uk.gov.hmrc.http.UpstreamErrorResponse
 
 class RootControllerSpec extends BaseISpec {
+
+  implicit lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  implicit lazy val mockAgentPermissionsConnector: AgentPermissionsConnector = mock[AgentPermissionsConnector]
+
+  lazy val sessioncacheRepo: SessionCacheRepository = new SessionCacheRepository(mongoComponent, timestampSupport)
+
+  override def moduleWithOverrides = new AbstractModule() {
+
+    override def configure(): Unit = {
+      bind(classOf[AuthAction]).toInstance(new AuthAction(mockAuthConnector, env, conf))
+      bind(classOf[AgentPermissionsConnector]).toInstance(mockAgentPermissionsConnector)
+      bind(classOf[SessionCacheRepository]).toInstance(sessioncacheRepo)
+    }
+  }
 
   override implicit lazy val fakeApplication: Application = appBuilder.build()
 
   val controller = fakeApplication.injector.instanceOf[RootController]
 
-  "root controller" should {
-    "have logic to decide where to go!" in {
-      val result = controller.start()(request)
+  "root controller" when {
+    "no session is available" should {
+      "retrieve opt-in status from backend and redirect to self if status available" in {
 
-      status(result) shouldBe SEE_OTHER
+        stubAuthorisationGrantAccess(mockedAuthResponse)
+        stubOptInStatusOk(arn)(OptedOutEligible)
 
-      redirectLocation(result).get shouldBe routes.OptInController.start.url
+        val result = controller.start()(request)
+
+        status(result) shouldBe SEE_OTHER
+
+        redirectLocation(result).get shouldBe routes.RootController.start.url
+      }
+
+      "throw an exception if there was no response from the backend" in {
+
+        stubAuthorisationGrantAccess(mockedAuthResponse)
+        stubOptInStatusError(arn)
+
+        intercept[UpstreamErrorResponse] {
+          await(controller.start()(request))
+        }
+      }
+    }
+
+    "a session is available" should {
+      "redirect to opt-in journey if the optin status is eligible to opt-in" in {
+
+        stubAuthorisationGrantAccess(mockedAuthResponse)
+        await(sessioncacheRepo.putSession(DATA_KEY, JourneySession(optinStatus = OptedOutEligible)))
+
+        val result = controller.start()(request)
+
+        status(result) shouldBe SEE_OTHER
+
+        redirectLocation(result).get shouldBe routes.OptInController.start.url
+      }
+
+      "redirect to opt-out journey if the optin status is eligible to opt-out" in {
+
+        stubAuthorisationGrantAccess(mockedAuthResponse)
+        await(sessioncacheRepo.putSession(DATA_KEY, JourneySession(optinStatus = OptedInReady)))
+
+        val result = controller.start()(request)
+
+        status(result) shouldBe SEE_OTHER
+
+        redirectLocation(result).get shouldBe routes.OptOutController.start.url
+      }
+
+      "redirect to ASA dashboard if user is not eligible to opt-in or opt-out" in {
+
+        stubAuthorisationGrantAccess(mockedAuthResponse)
+        await(sessioncacheRepo.putSession(DATA_KEY, JourneySession(optinStatus = OptedOutSingleUser)))
+
+        val result = controller.start()(request)
+
+        status(result) shouldBe SEE_OTHER
+
+        redirectLocation(result).get shouldBe "http://localhost:9401/agent-services-account/manage-account"
+      }
     }
   }
 

--- a/test/controllers/SessionBehaviourSpec.scala
+++ b/test/controllers/SessionBehaviourSpec.scala
@@ -72,7 +72,7 @@ class SessionBehaviourSpec extends BaseISpec with HttpClientMocks with AgentPerm
       status(result) shouldBe 200
     }
 
-    "if not eligible to opt-in then return 403" in {
+    "if not eligible to opt-in then redirect to root" in {
 
       mockHttpGet[HttpResponse](HttpResponse.apply(200, s""" "Opted-Out_SINGLE_USER" """))
       val result = await(testSessionBehaviour.withEligibleToOptIn(Arn(validArn)){ Future successful Results.Ok("")})
@@ -80,8 +80,8 @@ class SessionBehaviourSpec extends BaseISpec with HttpClientMocks with AgentPerm
 
       sessionStored.isDefined shouldBe true
 
-      status(result) shouldBe 403
-      bodyOf(result) shouldBe "not_eligible_to_opt-in"
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result.toFuture).get shouldBe routes.RootController.start.url
     }
   }
 
@@ -105,16 +105,18 @@ class SessionBehaviourSpec extends BaseISpec with HttpClientMocks with AgentPerm
       status(result) shouldBe 200
     }
 
-    "if not eligible to opt-out then return 403" in {
+    "if not eligible to opt-out then redirect to root" in {
 
-      mockHttpGet[HttpResponse](HttpResponse.apply(200, s""" "Opted-Out_SINGLE_USER" """))
+      mockHttpGet[HttpResponse](HttpResponse.apply(OK, s""" "Opted-Out_SINGLE_USER" """))
+
       val result = await(testSessionBehaviour.withEligibleToOptOut(Arn(validArn)){ Future successful Results.Ok("")})
+
       val sessionStored = await(testSessionBehaviour.sessionCacheRepository.getFromSession[JourneySession](DATA_KEY))
 
       sessionStored.isDefined shouldBe true
 
-      status(result) shouldBe 403
-      bodyOf(result) shouldBe "not_eligible_to_opt-out"
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result.toFuture).get shouldBe routes.RootController.start.url
     }
   }
 

--- a/test/helpers/AgentPermissionsConnectorMocks.scala
+++ b/test/helpers/AgentPermissionsConnectorMocks.scala
@@ -31,6 +31,11 @@ trait AgentPermissionsConnectorMocks extends MockFactory {
       .expects(arn, *, *)
       .returning(Future successful (Some(optinStatus)))
 
+  def stubOptInStatusError(arn: Arn)(implicit agentPermissionsConnector: AgentPermissionsConnector): Unit =
+    (agentPermissionsConnector.getOptinStatus(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(arn, *, *)
+      .throwing(UpstreamErrorResponse.apply("error", 503))
+
   def stubPostOptInAccepted(arn: Arn)(implicit agentPermissionsConnector: AgentPermissionsConnector): Unit =
     (agentPermissionsConnector.optin(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
       .expects(arn, *, *)

--- a/test/helpers/AgentUserClientDetailsConnectorMocks.scala
+++ b/test/helpers/AgentUserClientDetailsConnectorMocks.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package helpers
+
+import connectors.AgentUserClientDetailsConnector
+import org.scalamock.scalatest.MockFactory
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Enrolment}
+import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait AgentUserClientDetailsConnectorMocks extends MockFactory{
+
+  def stubGetClientListOk(arn: Arn)(clientList: Seq[Enrolment])(implicit agentUserClientDetailsConnector: AgentUserClientDetailsConnector): Unit =
+    (agentUserClientDetailsConnector.getClientList(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(arn, *, *)
+      .returning(Future successful (Some(clientList)))
+
+  def stubGetClientListAccepted(arn: Arn)(implicit agentUserClientDetailsConnector: AgentUserClientDetailsConnector): Unit =
+    (agentUserClientDetailsConnector.getClientList(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(arn, *, *)
+      .returning(Future successful None)
+
+  def stubGetClientListError(arn: Arn)(implicit agentUserClientDetailsConnector: AgentUserClientDetailsConnector): Unit =
+    (agentUserClientDetailsConnector.getClientList(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(arn, *, *)
+      .throwing(UpstreamErrorResponse.apply("error", 503))
+}

--- a/test/helpers/BaseISpec.scala
+++ b/test/helpers/BaseISpec.scala
@@ -46,6 +46,7 @@ abstract class BaseISpec extends AnyWordSpec
   with AgentPermissionsConnectorMocks
   with HttpClientMocks
   with CleanMongoCollectionSupport
+  with AgentUserClientDetailsConnectorMocks
 {
 
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global

--- a/test/helpers/TestData.scala
+++ b/test/helpers/TestData.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,19 +12,15 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@import config.AppConfig
-@import views.html.main_layout
+package helpers
 
-@this(layout: main_layout, p: p, h1: h1, h2: h2, link_as_button: link_as_button)
+import uk.gov.hmrc.agentmtdidentifiers.model.{Enrolment, Identifier}
 
-@(continueUrl: String)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+object TestData {
 
-@layout(
-    title = msgs("you-have-opted-in.h1", msgs("service.name"))) {
-    @h1("you-have-opted-in.h1")
-    @h2("you-have-opted-in.h2")
-    @p("you-have-opted-in.p")
-    @link_as_button(messageKey = "you-have-opted-in.button", href = continueUrl)
+  val clientListData = Seq(Enrolment("HMRC-MTD-VAT","Active", "Rapunzel", List(Identifier("VRN", "123456789"))))
+
+
 }


### PR DESCRIPTION
- when user selects 'yes' to opt-In then make the call to AUCD to get client list so the name fetch job is triggered.
- This may return 200 if all the names are available, in which case store the client list into the agent session (for now)
- If the call returns 202 then the names are not ready and no client list is stored.
- On the opt-In complete page (/you-have-opted-in) the continue button will either take them back to ASA dashboard (if response was Accepted) or redirect to /groups (if response was OK)