### PR TITLE
Updates URIs for AccessGroup backend endpoints

### DIFF
--- a/app/connectors/AgentPermissionsConnector.scala
+++ b/app/connectors/AgentPermissionsConnector.scala
@@ -102,7 +102,7 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)
 
 
   def createGroup(arn: Arn)(groupRequest: GroupRequest)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Done] = {
-    val url = s"$baseUrl/agent-permissions/arn/${arn.value}/group/create "
+    val url = s"$baseUrl/agent-permissions/arn/${arn.value}/groups"
     monitor("ConsumedAPI-createGroup-POST") {
       http.POST[GroupRequest, HttpResponse](url, groupRequest).map { response =>
         response.status match {
@@ -115,7 +115,7 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)
 
   def groupsSummaries(arn: Arn)
                      (implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[(Seq[GroupSummary], Seq[DisplayClient])]] =  {
-    val url = s"$baseUrl/agent-permissions/arn/${arn.value}/groups-information "
+    val url = s"$baseUrl/agent-permissions/arn/${arn.value}/groups"
     monitor("ConsumedAPI-groupSummaries-GET") {
       http.GET[HttpResponse](url).map { response: HttpResponse =>
         val eventuallySummaries = response.status match {
@@ -131,7 +131,7 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)
   }
 
   override def getGroup(id: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Option[AccessGroup]] = {
-    val url = s"$baseUrl/agent-permissions/gid/${id}/group"
+    val url = s"$baseUrl/agent-permissions/groups/${id}"
     monitor("ConsumedAPI-group-GET") {
       http.GET[HttpResponse](url).map { response: HttpResponse =>
         response.status match {

--- a/test/connectors/AgentPermissionsConnectorSpec.scala
+++ b/test/connectors/AgentPermissionsConnectorSpec.scala
@@ -96,7 +96,7 @@ class AgentPermissionsConnectorSpec extends BaseSpec with HttpClientMocks with A
     "return Done when response code is 201 CREATED" in {
 
       val groupRequest = GroupRequest("name of group", None, None)
-      val url = s"http://localhost:9447/agent-permissions/arn/${arn.value}/group/create "
+      val url = s"http://localhost:9447/agent-permissions/arn/${arn.value}/groups"
       val mockResponse = HttpResponse.apply(CREATED, "response Body")
       mockHttpPost[GroupRequest, HttpResponse](url, groupRequest, mockResponse)
       connector.createGroup(arn)(groupRequest).futureValue shouldBe Done
@@ -105,7 +105,7 @@ class AgentPermissionsConnectorSpec extends BaseSpec with HttpClientMocks with A
     "throw an exception for any other HTTP response code" in {
 
       val groupRequest = GroupRequest("name of group", None, None)
-      val url = s"http://localhost:9447/agent-permissions/arn/${arn.value}/group/create "
+      val url = s"http://localhost:9447/agent-permissions/arn/${arn.value}/groups"
       val mockResponse = HttpResponse.apply(INTERNAL_SERVER_ERROR, "")
       mockHttpPost[GroupRequest, HttpResponse](url, groupRequest, mockResponse)
       val caught = intercept[UpstreamErrorResponse] {
@@ -126,7 +126,7 @@ class AgentPermissionsConnectorSpec extends BaseSpec with HttpClientMocks with A
         groupSummaries,
         Set(Client("taxService~identKey~hmrcRef", "name"))
       )
-      val expectedUrl = s"http://localhost:9447/agent-permissions/arn/${arn.value}/groups-information"
+      val expectedUrl = s"http://localhost:9447/agent-permissions/arn/${arn.value}/groups"
       val mockJsonResponseBody = Json.toJson(groupSummaryResponse).toString
       val mockResponse = HttpResponse.apply(OK, mockJsonResponseBody)
 
@@ -168,7 +168,7 @@ class AgentPermissionsConnectorSpec extends BaseSpec with HttpClientMocks with A
         Some(Set(agent)),
         Some(Set(Enrolment("service", "state", "friendly", Seq(Identifier("key", "value"))))))
 
-      val expectedUrl = s"http://localhost:9447/agent-permissions/gid/${groupId}/group"
+      val expectedUrl = s"http://localhost:9447/agent-permissions/groups/${groupId}"
       val mockJsonResponseBody = Json.toJson(accessGroup).toString
       val mockResponse = HttpResponse.apply(OK, mockJsonResponseBody)
 


### PR DESCRIPTION

- Create access group: `POST /arn/:arn/groups`
- Fetch all group summaries: `GET /arn/:arn/groups`
- Fetch a group: `GET /groups/:gid`
- Delete a group: `DELETE /groups/:gid`
- Update a group: `PATCH /groups/:gid`