### PR TITLE
Apb 6188 [CS] add client_details page

### DIFF
--- a/app/connectors/AgentPermissionsConnector.scala
+++ b/app/connectors/AgentPermissionsConnector.scala
@@ -61,7 +61,7 @@ trait AgentPermissionsConnector extends HttpAPIMonitor with Logging {
   def getGroup(id: String)(implicit hc: HeaderCarrier,
                            ec: ExecutionContext): Future[Option[AccessGroup]]
 
-  def getGroupsForClient(arn: Arn, enrolmentKey: String)(implicit hc: HeaderCarrier,
+  def getGroupsForClient(arn: Arn, enrolment: Enrolment)(implicit hc: HeaderCarrier,
                                                          ec: ExecutionContext): Future[Option[Seq[GroupSummary]]]
 
   def updateGroup(id: String, groupRequest: UpdateAccessGroupRequest)(
@@ -194,21 +194,22 @@ class AgentPermissionsConnectorImpl @Inject()(val http: HttpClient)(
     }
   }
 
-  def getGroupsForClient(arn: Arn, enrolmentKey: String)(implicit hc: HeaderCarrier,
+  def getGroupsForClient(arn: Arn, enrolment: Enrolment)(implicit hc: HeaderCarrier,
                                 ec: ExecutionContext): Future[Option[Seq[GroupSummary]]] = {
+    val enrolmentKey = EnrolmentKey.enrolmentKeys(enrolment).head
     val url = s"$baseUrl/agent-permissions/arn/${arn.value}/client/$enrolmentKey/groups"
     monitor("ConsumedAPI-groupSummariesForClient-GET") {
       http.GET[HttpResponse](url).map { response: HttpResponse =>
         val eventuallySummaries = response.status match {
-          case OK => response.json.asOpt[AccessGroupSummaries]
+          case OK => response.json.asOpt[Seq[GroupSummary]]
           case NOT_FOUND => None
           case e =>
             throw UpstreamErrorResponse(
-              s"error getting group summary for arn: $arn, client: $enrolmentKey from $url",
+              s"error getting group summary for arn: $arn, client: $enrolment from $url",
               e)
         }
         val maybeGroups = eventuallySummaries.map { summaries =>
-          summaries.groups
+          summaries
         }
         maybeGroups
       }

--- a/app/controllers/ManageClientController.scala
+++ b/app/controllers/ManageClientController.scala
@@ -19,21 +19,19 @@ package controllers
 import config.AppConfig
 import connectors.AgentPermissionsConnector
 import forms.AddClientsToGroupForm
-import models.{ButtonSelect, DisplayClient, DisplayGroup, TeamMember}
+import models.{ButtonSelect, DisplayClient}
 import play.api.Logging
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.libs.json.Json
-import play.api.libs.json.Json.{parse, toJson}
 import play.api.mvc._
 import repository.SessionCacheRepository
 import services.{GroupService, SessionCacheService}
-import uk.gov.hmrc.agentmtdidentifiers.model.EnrolmentKey.enrolmentKey
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.group_member_details._
 
 import java.util.Base64.{getDecoder, getEncoder}
 import javax.inject.{Inject, Singleton}
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
 @Singleton
 class ManageClientController @Inject()(
@@ -125,7 +123,7 @@ class ManageClientController @Inject()(
           groupService.groupSummariesForClient(arn, clientJson.get).flatMap { maybeGroups =>
             Ok(client_details(
               client = clientJson.get,
-              clientGroups = Some(maybeGroups)
+              clientGroups = maybeGroups
             )).toFuture
         }
       }

--- a/app/controllers/ManageClientController.scala
+++ b/app/controllers/ManageClientController.scala
@@ -26,7 +26,7 @@ import play.api.mvc._
 import repository.SessionCacheRepository
 import services.{GroupService, SessionCacheService}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
-import views.html.group_member_details.manage_clients_list
+import views.html.group_member_details._
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -37,6 +37,7 @@ class ManageClientController @Inject()(
      mcc: MessagesControllerComponents,
      groupService: GroupService,
      manage_clients_list: manage_clients_list,
+     client_details: client_details,
      val agentPermissionsConnector: AgentPermissionsConnector,
      val sessionCacheRepository: SessionCacheRepository,
      val sessionCacheService: SessionCacheService)
@@ -110,7 +111,7 @@ class ManageClientController @Inject()(
 
   def showClientDetails(clientId :String): Action[AnyContent] = Action.async { implicit request =>
     isAuthorisedAgent { arn =>
-      Ok(s"showClientDetails for $clientId not yet implemented $arn").toFuture
+      Ok(client_details()).toFuture
     }
   }
 

--- a/app/models/DisplayGroup.scala
+++ b/app/models/DisplayGroup.scala
@@ -17,7 +17,7 @@
 package models
 
 import play.api.libs.json.Json
-import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, Client, Enrolment}
+import uk.gov.hmrc.agentmtdidentifiers.model.AccessGroup
 
 case class DisplayGroup(
     _id: String,

--- a/app/services/GroupService.scala
+++ b/app/services/GroupService.scala
@@ -25,7 +25,7 @@ import play.api.Logging
 import play.api.libs.json.{Reads, Writes}
 import play.api.mvc.Request
 import repository.SessionCacheRepository
-import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, EnrolmentKey}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.mongo.cache.DataKey
 
@@ -321,8 +321,8 @@ class GroupService @Inject()(
 
   def groupSummariesForClient(arn: Arn, client: DisplayClient)
                     (implicit request: Request[_], ec: ExecutionContext, hc: HeaderCarrier): Future[Seq[GroupSummary]] = {
-    val enrolmentKey = toEnrolment(client)
-    val groupSummaries = agentPermissionsConnector.getGroupsForClient(arn, enrolmentKey.toString).map {
+    val enrolment = toEnrolment(client)
+    val groupSummaries = agentPermissionsConnector.getGroupsForClient(arn, enrolment).map {
           case Some(gs) => gs
           case None => Seq.empty
         }

--- a/app/utils/ViewUtils.scala
+++ b/app/utils/ViewUtils.scala
@@ -52,4 +52,12 @@ object ViewUtils {
     }
   }
 
+  def displayNameOrFullReference(name: String, taxId: String): String = {
+    if(name.isEmpty) {
+      taxId
+    } else {
+      name
+    }
+  }
+
 }

--- a/app/utils/ViewUtils.scala
+++ b/app/utils/ViewUtils.scala
@@ -42,9 +42,14 @@ object ViewUtils {
     }
   }
 
-  def displayObfuscatedReference(taxId: String): String = {
-    // TODO - change obfuscation depending on reference?
-    "ending in ".concat(taxId.substring(taxId.length - 4))
+  // can only display full taxId if no name
+  def displayObfuscatedReference(name: String, taxId: String): String = {
+    if(name.isEmpty) {
+      taxId
+    } else {
+      // TODO - change obfuscation depending on reference?
+      "ending in ".concat(taxId.substring(taxId.length - 4))
+    }
   }
 
 }

--- a/app/views/group_member_details/client_details.scala.html
+++ b/app/views/group_member_details/client_details.scala.html
@@ -1,0 +1,76 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import controllers.routes
+@import views.html.main_layout
+@import utils.ViewUtils._
+@import models.AddClientsToGroup
+@import views.html.partials.filter_clients_table_form
+
+@this(
+        layout: main_layout,
+        h1: h1, h2: h2, h3: h3,
+        p:p, a: a, span: span
+)
+
+@(
+    client: Option[DisplayClient] = None
+)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+
+@clientReference = @{
+Html(msgs("details.clients.no-data")+ "  " + a("common.update", href = "#"))
+}
+
+@displayTaxReference = @{
+Html("BLAH567890")
+}
+
+@layout(
+    title = msgs("details.clients"),
+    backLinkHref = Some(routes.ManageClientController.showAllClients.url),
+    fullWidth = true
+) {
+
+<div class="govuk-grid-row">
+    @h1("details.clients", classes = Some("govuk-grid-column-two-thirds"))
+
+    <div class="govuk-grid-column-two-thirds">
+        @h3("group.client.list.table.th1")
+        @p(html = Some(clientReference))
+
+        @h3("group.client.list.table.th2")
+        @p(html = Some(displayTaxReference))
+
+        @h3("group.client.list.table.th3")
+        @p("VAT")
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        @a("common.return.manage-clients", href = routes.ManageClientController.showAllClients.url)
+
+    </div>
+
+    <div class="govuk-grid-column-one-third">
+       @h2("common.details.groups.header")
+
+        @p("common.details.not-assigned")
+
+        @a("common.details.assign-to-group", href="#")
+    </div>
+</div>
+
+}

--- a/app/views/group_member_details/client_details.scala.html
+++ b/app/views/group_member_details/client_details.scala.html
@@ -30,7 +30,7 @@
 
 @(
     client: DisplayClient,
-    clientGroups: Option[Seq[GroupSummary]]
+    clientGroups: Seq[GroupSummary]
 )(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
 
 @clientReference = @{
@@ -50,19 +50,6 @@
 
 }
 
-@maybeGroups = @{
-    if(clientGroups.isEmpty) {
-
-        p("common.details.not-assigned")
-
-        a("common.details.assign-to-group", href="#")
-
-    } else {
-        "Groups here"
-        a("group.name.here", href=routes.ManageGroupController.showExistingGroupClients("groupId").url)
-    }
-}
-
 @layout(
     title = msgs("details.clients"),
     backLinkHref = Some(routes.ManageClientController.showAllClients.url),
@@ -71,8 +58,6 @@
 
 <div class="govuk-grid-row">
     @h1("details.clients", classes = Some("govuk-grid-column-two-thirds"))
-
-    @clientGroups.getOrElse("")
 
     <div class="govuk-grid-column-two-thirds">
         @h3("group.client.list.table.th1")
@@ -95,13 +80,19 @@
 
         @if(clientGroups.isEmpty) {
 
-            p("common.details.not-assigned")
+            @p("common.details.not-assigned")
 
-            a("common.details.assign-to-group", href="#")
+            @a("common.details.assign-to-group", href="#")
 
         } else {
-        "Groups here"
-        a("group.name.here", href=routes.ManageGroupController.showExistingGroupClients("groupId").url)
+
+        <ul class="govuk-list">
+            @for(group <- clientGroups) {
+            <li class="govuk-list--item">@a(group.groupName, href=routes.ManageGroupController.showExistingGroupClients(group.groupId).url)</li>
+            }
+        </ul>
+
+
         }
 
     </div>

--- a/app/views/group_member_details/client_details.scala.html
+++ b/app/views/group_member_details/client_details.scala.html
@@ -19,6 +19,7 @@
 @import views.html.main_layout
 @import utils.ViewUtils._
 @import models.AddClientsToGroup
+@import connectors.GroupSummary
 @import views.html.partials.filter_clients_table_form
 
 @this(
@@ -28,15 +29,38 @@
 )
 
 @(
-    client: Option[DisplayClient] = None
+    client: DisplayClient,
+    clientGroups: Option[Seq[GroupSummary]]
 )(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
 
 @clientReference = @{
-Html(msgs("details.clients.no-data")+ "  " + a("common.update", href = "#"))
+    if(client.name.isEmpty) {
+        Html(msgs("details.clients.no-data")+ "  " + a("common.update", href = "#"))
+    } else {
+        Html(client.name + "  " + a("common.update", href = "#"))
+    }
 }
 
 @displayTaxReference = @{
-Html("BLAH567890")
+    if(client.name.isEmpty) {
+        Html(client.hmrcRef)
+    } else {
+        Html(displayObfuscatedReference(client.hmrcRef))
+    }
+
+}
+
+@maybeGroups = @{
+    if(clientGroups.isEmpty) {
+
+        p("common.details.not-assigned")
+
+        a("common.details.assign-to-group", href="#")
+
+    } else {
+        "Groups here"
+        a("group.name.here", href=routes.ManageGroupController.showExistingGroupClients("groupId").url)
+    }
 }
 
 @layout(
@@ -48,6 +72,8 @@ Html("BLAH567890")
 <div class="govuk-grid-row">
     @h1("details.clients", classes = Some("govuk-grid-column-two-thirds"))
 
+    @clientGroups.getOrElse("")
+
     <div class="govuk-grid-column-two-thirds">
         @h3("group.client.list.table.th1")
         @p(html = Some(clientReference))
@@ -56,7 +82,7 @@ Html("BLAH567890")
         @p(html = Some(displayTaxReference))
 
         @h3("group.client.list.table.th3")
-        @p("VAT")
+        @p(displayTaxServiceFromServiceKey(client.taxService))
 
         <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
@@ -65,11 +91,19 @@ Html("BLAH567890")
     </div>
 
     <div class="govuk-grid-column-one-third">
-       @h2("common.details.groups.header")
+        @h2("common.details.groups.header")
 
-        @p("common.details.not-assigned")
+        @if(clientGroups.isEmpty) {
 
-        @a("common.details.assign-to-group", href="#")
+            p("common.details.not-assigned")
+
+            a("common.details.assign-to-group", href="#")
+
+        } else {
+        "Groups here"
+        a("group.name.here", href=routes.ManageGroupController.showExistingGroupClients("groupId").url)
+        }
+
     </div>
 </div>
 

--- a/app/views/group_member_details/client_details.scala.html
+++ b/app/views/group_member_details/client_details.scala.html
@@ -42,12 +42,7 @@
 }
 
 @displayTaxReference = @{
-    if(client.name.isEmpty) {
-        Html(client.hmrcRef)
-    } else {
-        Html(displayObfuscatedReference(client.hmrcRef))
-    }
-
+    Html(displayObfuscatedReference(client.name, client.hmrcRef))
 }
 
 @layout(
@@ -92,6 +87,7 @@
             }
         </ul>
 
+            @a("common.details.assign-to-group", href="#")
 
         }
 

--- a/app/views/groups/group_created.scala.html
+++ b/app/views/groups/group_created.scala.html
@@ -32,7 +32,7 @@
 
     @h2("common.what.happens.next")
     @p("group.created.p")
-    @a("group.created.a", href = appConfig.agentServicesAccountManageAccountUrl)
+    @a("common.return.manage-account", href = appConfig.agentServicesAccountManageAccountUrl)
 
 }
 

--- a/app/views/groups/manage/existing_clients.scala.html
+++ b/app/views/groups/manage/existing_clients.scala.html
@@ -36,7 +36,7 @@
     group.clients.map(client =>
         Seq(
             Html(client.name),
-            Html(displayObfuscatedReference(client.hmrcRef)),
+            Html(displayObfuscatedReference(client.name, client.hmrcRef)),
             Html(displayTaxServiceFromServiceKey(client.taxService))
         )
     )

--- a/app/views/groups/review_clients_to_add.scala.html
+++ b/app/views/groups/review_clients_to_add.scala.html
@@ -41,7 +41,7 @@
         clients.map(client =>
             Seq(
                 Html(client.name),
-                Html(displayObfuscatedReference(client.hmrcRef)),
+                Html(displayObfuscatedReference(client.name, client.hmrcRef)),
                 Html(displayTaxServiceFromServiceKey(client.taxService))
             )
         )

--- a/app/views/groups/team_members_list.scala.html
+++ b/app/views/groups/team_members_list.scala.html
@@ -122,7 +122,7 @@ errorPrefix.concat(msgs("group.members.list.h1", groupName))
                 attrs = Map("data-module" -> "moj-multi-select", "data-multi-select-checkbox" -> "#select-all"),
                 headings = Seq(
                 (
-                    Html(span(id=Some("no-js"), classes=Some("govuk-visually-hidden"), key="group.client.list.table.checkbox").toString),
+                    span(id=Some("no-js"), classes=Some("govuk-visually-hidden"), key="group.client.list.table.checkbox"),
                     Map("id" -> "select-all")
                 ),
                 (

--- a/app/views/partials/filter_clients_table_form.scala.html
+++ b/app/views/partials/filter_clients_table_form.scala.html
@@ -42,7 +42,7 @@
     clients.fold(Seq.empty[Seq[Html]])(_.map(client =>
         Seq(
             Html(client.name),
-            Html(displayObfuscatedReference(client.hmrcRef)),
+            Html(displayObfuscatedReference(client.name, client.hmrcRef)),
             Html(displayTaxServiceFromServiceKey(client.taxService)),
             a(key="details.clients", href= routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url)
         )

--- a/app/views/partials/filter_clients_table_form.scala.html
+++ b/app/views/partials/filter_clients_table_form.scala.html
@@ -44,7 +44,13 @@
             Html(client.name),
             Html(displayObfuscatedReference(client.name, client.hmrcRef)),
             Html(displayTaxServiceFromServiceKey(client.taxService)),
-            a(key="details.clients", href= routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url)
+            a(
+                key=Html(msgs("details.clients") + span(classes=Some("govuk-visually-hidden"),
+                                                        html=Some(Html(msgs("details.link-hidden", displayNameOrFullReference(client.name, client.hmrcRef))))
+                                                        ).toString
+                ).toString,
+                href= routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url
+            )
         )
     )
     )

--- a/app/views/partials/filter_clients_table_form.scala.html
+++ b/app/views/partials/filter_clients_table_form.scala.html
@@ -44,7 +44,7 @@
             Html(client.name),
             Html(displayObfuscatedReference(client.hmrcRef)),
             Html(displayTaxServiceFromServiceKey(client.taxService)),
-            a(key="details.clients", href= routes.ManageClientController.showClientDetails("test").url)
+            a(key="details.clients", href= routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url)
         )
     )
     )

--- a/app/views/partials/selectable_clients_table_form.scala.html
+++ b/app/views/partials/selectable_clients_table_form.scala.html
@@ -58,7 +58,7 @@
                 ).toString
             ),
             Html(client.name),
-            Html(displayObfuscatedReference(client.hmrcRef)),
+            Html(displayObfuscatedReference(client.name, client.hmrcRef)),
             Html(displayTaxServiceFromServiceKey(client.taxService)),
         )
     )

--- a/app/views/you_have_opted_out.scala.html
+++ b/app/views/you_have_opted_out.scala.html
@@ -27,7 +27,7 @@
     @p("you-have-opted-out.p1")
     @p("you-have-opted-out.p2")
     @link_as_button(
-        key = "you-have-opted-out.button",
+        key = "common.return.manage-account",
         href = appConfig.agentServicesAccountManageAccountUrl
     )
 }

--- a/conf/messages
+++ b/conf/messages
@@ -12,16 +12,22 @@ continue=Continue
 common.what.happens.next=What happens next?
 common.change=Change
 common.actions=Actions
-
+common.update=Update
 common.clients=Clients
 common.teamMembers=Team members
 
 continue.button=Continue
 save.and.continue.button=Save and continue
 submit.button=Submit
+
 filter.legend=Filters
 filter.apply=Apply filters
 filter.clear=Clear filters
+
+common.return.to.dashboard=Return to manage access groups
+common.return.to.unassigned.clients=Return to unassigned clients
+common.return.manage-account=Return to manage account
+common.return.manage-clients=Return to manage clients
 
 error.select-clients.empty=You must select at least one client
 error.search-filter.empty=You must enter a tax reference, client name or select a tax service to apply filters
@@ -73,7 +79,6 @@ you-have-opted-out.h1=You have opted out of using access groups
 you-have-opted-out.h2=What happens next
 you-have-opted-out.p1=You will need to log out and log back in to see this change, after which all users will be able to view all clients.
 you-have-opted-out.p2=Your account will show that you have chosen to opt out of using access groups. If you wish to opt in to use this feature again you can do so from your agent services manage account page.
-you-have-opted-out.button=Return to manage account
 
 group.create.h1=Create an access group
 group.create.name.label=What do you want to call this access group?
@@ -119,7 +124,6 @@ cya.inset=The team members you have selected will have permission to view and ma
 group.created.h1=Access group created
 group.created.panelContent={0} access group is now active
 group.created.p=The team members you selected can now view and manage the tax affairs of all the clients in this access group
-group.created.a=Return to manage account
 
 group.manage.h1=Manage access groups
 group.manage.p=The team members in the group will be able to manage the tax affairs of clients in the group
@@ -146,8 +150,6 @@ group.renamed.h1=Access group renamed
 group.renamed.panelContent=<strong>{0}</strong> access group renamed to <strong>{1}</strong>
 group.renamed.p=You can rename groups any time from the ‘manage access groups’ section
 
-common.return.to.dashboard=Return to manage access groups
-
 group.delete.h1=Delete group
 group.delete.name.label=Are you sure you want to delete {0} access group?
 group.delete.select.error=Select ‘yes’ if you would like to delete the group.
@@ -172,13 +174,14 @@ unassigned.client.assign.nothing.selected.error=You must select an access group 
 
 clients.assigned.complete.h1=Clients added to access groups
 clients.assigned.complete.p=You have added these clients to the following groups:
-common.return.to.unassigned.clients=Return to unassigned clients
 
 
 details.clients=Client details
-common.details.assign-to-group=Assign to an access group
 details.team-members=Team member details
 details.link-hidden= for {0}
+
+common.details.assign-to-group=Assign to an access group
+common.details.groups.header=Member of these groups
 
 error.group.filter.max.length=You can only enter 32 characters or fewer
 error.group.filter.required=You must enter a group name or part of it

--- a/conf/messages
+++ b/conf/messages
@@ -177,10 +177,12 @@ clients.assigned.complete.p=You have added these clients to the following groups
 
 
 details.clients=Client details
+details.clients.no-data=We could not retrieve this
 details.team-members=Team member details
 details.link-hidden= for {0}
 
 common.details.assign-to-group=Assign to an access group
+common.details.not-assigned=Not assigned to an access group
 common.details.groups.header=Member of these groups
 
 error.group.filter.max.length=You can only enter 32 characters or fewer

--- a/test/controllers/ManageClientControllerSpec.scala
+++ b/test/controllers/ManageClientControllerSpec.scala
@@ -153,7 +153,7 @@ class ManageClientControllerSpec extends BaseSpec {
       trs.get(0).select("td").get(0).text() shouldBe "friendly0"
       trs.get(0).select("td").get(1).text() shouldBe "ending in 6780"
       trs.get(0).select("td").get(2).text() shouldBe "VAT"
-      trs.get(0).select("td").get(3).text() shouldBe "Client details"
+      trs.get(0).select("td").get(3).text() shouldBe "Client details for friendly0"
     }
 
   }

--- a/test/helpers/AgentPermissionsConnectorMocks.scala
+++ b/test/helpers/AgentPermissionsConnectorMocks.scala
@@ -19,9 +19,10 @@ package helpers
 import akka.Done
 import connectors.{AgentPermissionsConnector, GroupRequest, GroupSummary, UpdateAccessGroupRequest}
 import models.DisplayClient
+import org.scalamock.handlers.CallHandler4
 import org.scalamock.scalatest.MockFactory
-import play.api.http.Status.{BAD_REQUEST, OK}
-import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, Arn, OptinStatus}
+import play.api.http.Status.BAD_REQUEST
+import uk.gov.hmrc.agentmtdidentifiers.model.{AccessGroup, Arn, Enrolment, OptinStatus}
 import uk.gov.hmrc.http.{HeaderCarrier, UpstreamErrorResponse}
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -33,7 +34,7 @@ trait AgentPermissionsConnectorMocks extends MockFactory {
     (agentPermissionsConnector
       .getOptInStatus(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
       .expects(arn, *, *)
-      .returning(Future successful (Some(optinStatus)))
+      .returning(Future successful Some(optinStatus))
 
   def stubOptInStatusError(arn: Arn)(
       implicit agentPermissionsConnector: AgentPermissionsConnector): Unit =
@@ -87,6 +88,16 @@ trait AgentPermissionsConnectorMocks extends MockFactory {
       .groupsSummaries(_: Arn)(_: HeaderCarrier, _: ExecutionContext))
       .expects(arn, *, *)
       .returning(Future successful summaries)
+
+  def expectGetGroupsForClientSuccess(
+                                    arn: Arn,
+                                    enrolment: Enrolment,
+                                    groups: Option[Seq[GroupSummary]])(
+                                    implicit agentPermissionsConnector: AgentPermissionsConnector): Unit =
+    (agentPermissionsConnector
+      .getGroupsForClient(_: Arn, _: Enrolment)(_: HeaderCarrier, _: ExecutionContext))
+      .expects(arn, enrolment, *, *)
+      .returning(Future successful groups)
 
   def expectGetGroupSuccess(id: String, group: Option[AccessGroup])(
       implicit agentPermissionsConnector: AgentPermissionsConnector): Unit =


### PR DESCRIPTION
- add client_details page
- updated the display obfuscated taxId method to show full taxId if there is no name
- a11y fix for "Client details" link, now has visually hidden for {name or taxId if no name}