### PR TITLE
APB-6189 [CS] add update client ref journey

### DIFF
--- a/app/assets/stylesheets/moj-frontend.min.css
+++ b/app/assets/stylesheets/moj-frontend.min.css
@@ -1,2 +1,3622 @@
-@charset "UTF-8";.moj-filter-layout:after{clear:both;content:"";display:block}.moj-filter-layout__filter{box-shadow:inset 0 0 0 1px #f3f2f1}@media (min-width:48.0625em){.moj-filter-layout__filter{float:left;margin-right:40px;max-width:385px;min-width:260px;width:100%}}@media (max-width:48.0525em){.js-enabled .moj-filter-layout__filter{background-color:#fff;bottom:0;overflow-y:scroll;position:fixed;right:0;top:0;z-index:100}}.moj-filter-layout__content{overflow:hidden;overflow-x:auto}@media (max-width:63.75em){.moj-scrollable-pane{clear:both;overflow:hidden;position:relative}.moj-scrollable-pane:after{border-radius:10px 0 0 10px/50% 0 0 50%;box-shadow:-5px 0 10px rgba(0,0,0,.25);content:"";height:100%;left:100%;position:absolute;top:0;width:50px}.moj-scrollable-pane__wrapper{overflow-x:auto}.moj-scrollable-pane__wrapper .govuk-table__cell,.moj-scrollable-pane__wrapper .govuk-table__header{white-space:nowrap}}@media (max-width:63.75em){.moj-scrollable-pane>div::-webkit-scrollbar{height:10px}.moj-scrollable-pane>div::-webkit-scrollbar-track{background:#f3f2f1;box-shadow:inset 0 0 2px rgba(0,0,0,.15)}.moj-scrollable-pane>div::-webkit-scrollbar-thumb{background:#505a5f;border-radius:5px}}.moj-action-bar{font-size:0}.moj-action-bar__filter{display:inline-block;position:relative}@media (max-width:48.0525em){.moj-action-bar__filter{float:right}}@media (min-width:48.0625em){.moj-action-bar__filter{margin-right:10px;padding-right:12px}.moj-action-bar__filter:after{background-color:#f3f2f1;content:"";height:40px;position:absolute;right:0;top:0;width:2px}}.moj-add-another__item{margin:30px 0 0;padding:0;position:relative}.moj-add-another__item:first-of-type{margin-top:0}.moj-add-another__title{float:left;padding:4px 100px 4px 0;width:100%}.moj-add-another__title+.govuk-form-group{clear:left}.moj-add-another__remove-button{position:absolute;right:0;top:0;width:auto}.moj-add-another__add-button{display:block}.moj-add-another__heading:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none}.moj-badge{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;border:2px solid #1d70b8;color:#1d70b8;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:12px;font-size:.75rem;font-weight:700;line-height:1.25;outline:2px solid transparent;outline-offset:-2px;padding:0 5px;text-transform:uppercase;vertical-align:middle}
-/*! Copyright (c) 2011 by Margaret Calvert & Henrik Kubel. All rights reserved. The font has been customised for exclusive use on gov.uk. This cut is not commercially available. */@font-face{font-display:fallback;font-family:GDS Transport;font-style:normal;font-weight:400;src:url(/assets/fonts/light-94a07e06a1-v2.woff2) format("woff2"),url(/assets/fonts/light-f591b13f7d-v2.woff) format("woff")}@font-face{font-display:fallback;font-family:GDS Transport;font-style:normal;font-weight:700;src:url(/assets/fonts/bold-b542beb274-v2.woff2) format("woff2"),url(/assets/fonts/bold-affa96571d-v2.woff) format("woff")}@media print{.moj-badge{font-family:sans-serif}}@media (min-width:40.0625em){.moj-badge{font-size:14px;font-size:.875rem;line-height:1.4285714286}}@media print{.moj-badge{font-size:12pt;line-height:1.2}}.moj-badge--purple{border-color:#4c2c92;color:#4c2c92}.moj-badge--bright-purple{border-color:#912b88;color:#912b88}.moj-badge--red{border-color:#d4351c;color:#d4351c}.moj-badge--green{border-color:#00703c;color:#00703c}.moj-badge--blue{border-color:#1d70b8;color:#1d70b8}.moj-badge--black{border-color:#0b0c0c;color:#0b0c0c}.moj-badge--grey{border-color:#505a5f;color:#505a5f}.moj-badge--large{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.1428571429}@media print{.moj-badge--large{font-family:sans-serif}}@media (min-width:40.0625em){.moj-badge--large{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-badge--large{font-size:14pt;line-height:1.2}}.moj-banner{border:5px solid #1d70b8;color:#1d70b8;font-size:0;margin-bottom:30px;padding:10px}.moj-banner__icon{fill:currentColor;float:left;margin-right:10px}.moj-banner__message{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#0b0c0c;display:block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;overflow:hidden}@media print{.moj-banner__message{font-family:sans-serif}}@media (min-width:40.0625em){.moj-banner__message{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-banner__message{font-size:14pt;line-height:1.15}}.moj-banner__message h2{margin-bottom:10px}.moj-banner__message h2:last-child,.moj-banner__message p:last-child{margin-bottom:0}.moj-banner__assistive{clip:rect(0 0 0 0)!important;border:0!important;-webkit-clip-path:inset(50%)!important;clip-path:inset(50%)!important;height:1px!important;margin:0!important;overflow:hidden!important;padding:0!important;position:absolute!important;white-space:nowrap!important;width:1px!important}.moj-banner--success{border-color:#00703c;color:#00703c}.moj-banner--warning{border-color:#d4351c;color:#d4351c}.moj-button-menu{display:inline-block;position:relative}.moj-button-menu__toggle-button{display:inline-block;margin-bottom:10px;margin-right:10px;width:auto}.moj-button-menu__toggle-button:last-child{margin-right:0}.moj-button-menu__toggle-button:after{background-image:url(/assets/images/icon-arrow-white-down.svg);background-repeat:no-repeat;content:"";display:inline-block;height:5px;margin-left:10px;vertical-align:middle;width:10px}.moj-button-menu__toggle-button:focus:after{background-image:url(/assets/images/icon-arrow-black-down.svg)}.moj-button-menu__toggle-button[aria-expanded=true]:focus:after{background-image:url(/assets/images/icon-arrow-black-up.svg)}.moj-button-menu__toggle-button:hover:after{background-image:url(/assets/images/icon-arrow-white-down.svg)}.moj-button-menu__toggle-button[aria-expanded=true]:after,.moj-button-menu__toggle-button[aria-expanded=true]:hover:after{background-image:url(/assets/images/icon-arrow-white-up.svg)}.moj-button-menu__toggle-button--secondary{margin-bottom:5px;margin-right:0}.moj-button-menu__toggle-button--secondary:after{background-image:url(/assets/images/icon-arrow-black-down.svg)}.moj-button-menu__toggle-button--secondary[aria-expanded=true]:after{background-image:url(/assets/images/icon-arrow-black-up.svg)}.moj-button-menu__toggle-button--secondary:hover:after{background-image:url(/assets/images/icon-arrow-black-down.svg)}.moj-button-menu__toggle-button--secondary[aria-expanded=true]:hover:after{background-image:url(/assets/images/icon-arrow-black-up.svg)}.moj-button-menu__item{display:inline-block;margin-bottom:10px;margin-right:10px;width:auto}.moj-button-menu__item:last-child{margin-right:0}.moj-button-menu [role=menuitem]{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;-webkit-appearance:none;background-color:#f3f2f1;border:none;box-sizing:border-box;-webkit-box-sizing:border-box;display:block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-bottom:0;padding:10px;text-align:left;width:100%}@media print{.moj-button-menu [role=menuitem]{font-family:sans-serif}}@media (min-width:40.0625em){.moj-button-menu [role=menuitem]{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-button-menu [role=menuitem]{font-size:14pt;line-height:1.15}}.moj-button-menu [role=menuitem]:link,.moj-button-menu [role=menuitem]:visited{color:#0b0c0c;text-decoration:none}.moj-button-menu [role=menuitem]:hover{background-color:#b1b4b6}.moj-button-menu [role=menuitem]:focus{outline:3px solid #fd0;outline-offset:0;position:relative;z-index:10}.moj-button-menu__wrapper{font-size:0}.moj-button-menu__wrapper--right{right:0}.moj-button-menu [role=menu]{position:absolute;width:200px;z-index:10}.moj-button-menu [aria-expanded=true]+[role=menu]{display:block}.moj-button-menu [aria-expanded=false]+[role=menu]{display:none}.govuk-width-container{margin-left:15px;margin-right:15px;max-width:960px}@supports (margin:max(calc(0px))){.govuk-width-container{margin-left:max(15px,calc(15px + env(safe-area-inset-left)));margin-right:max(15px,calc(15px + env(safe-area-inset-right)))}}@media (min-width:40.0625em){.govuk-width-container{margin-left:30px;margin-right:30px}@supports (margin:max(calc(0px))){.govuk-width-container{margin-left:max(30px,calc(15px + env(safe-area-inset-left)));margin-right:max(30px,calc(15px + env(safe-area-inset-right)))}}}@media (min-width:1020px){.govuk-width-container{margin-left:auto;margin-right:auto}@supports (margin:max(calc(0px))){.govuk-width-container{margin-left:auto;margin-right:auto}}}.moj-cookie-banner{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#fff;box-sizing:border-box;display:none;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;left:15px;line-height:1.1428571429;padding-bottom:15px;padding-right:15px;padding-top:15px}@media print{.moj-cookie-banner{font-family:sans-serif}}@media (min-width:40.0625em){.moj-cookie-banner{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-cookie-banner{font-size:14pt;line-height:1.2}}.moj-cookie-banner--show{display:block!important}.moj-cookie-banner__message{margin:0 15px;max-width:960px}@supports (margin:max(calc(0px))){.moj-cookie-banner__message{margin-left:max(15px,calc(15px + env(safe-area-inset-left)));margin-right:max(15px,calc(15px + env(safe-area-inset-right)))}}@media (min-width:40.0625em){.moj-cookie-banner__message{margin-left:30px;margin-right:30px}@supports (margin:max(calc(0px))){.moj-cookie-banner__message{margin-left:max(30px,calc(15px + env(safe-area-inset-left)));margin-right:max(30px,calc(15px + env(safe-area-inset-right)))}}}@media (min-width:1020px){.moj-cookie-banner__message{margin-left:auto;margin-right:auto}@supports (margin:max(calc(0px))){.moj-cookie-banner__message{margin-left:auto;margin-right:auto}}}.moj-cookie-banner__buttons .govuk-grid-column-full{padding-left:0}@media (min-width:40.0625em){.moj-cookie-banner .govuk-button{width:90%}}@media print{.moj-cookie-banner{display:none!important}}.moj-label__currency{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#f3f2f1;border-right:2px solid #0b0c0c;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin:2px 0 0 2px!important;padding:5.5px 12px;position:absolute}@media print{.moj-label__currency{font-family:sans-serif}}@media (min-width:40.0625em){.moj-label__currency{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-label__currency{font-size:14pt;line-height:1.15}}.moj-label__currency--error{background-color:#d4351c;border-right:2px solid #d4351c;color:#fff}@media (max-width:40.0525em){.moj-label__currency{padding:8px 12px}}.moj-input__currency{margin:0;padding-left:40px}.moj-filter{background-color:#fff;box-shadow:inset 0 0 0 1px #b1b4b6}.moj-filter:focus{box-shadow:0 -2px #fd0,0 4px #0b0c0c}.moj-filter__header{background-color:#b1b4b6;font-size:0;padding:10px 20px;text-align:justify}.moj-filter__header:after{content:"";display:inline-block;width:100%}.moj-filter__header [class^=govuk-heading-]{margin-bottom:0}.moj-filter__legend{overflow:visible;width:100%}.moj-filter__legend button{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;-webkit-appearance:none;background-color:transparent;border:0;border-radius:0;box-sizing:border-box;cursor:pointer;display:block;font-family:GDS Transport,arial,sans-serif;font-size:18px;font-size:1.125rem;font-weight:700;line-height:1.1111111111;margin:0;padding:0;position:relative;text-align:left;width:100%}@media print{.moj-filter__legend button{font-family:sans-serif}}@media (min-width:40.0625em){.moj-filter__legend button{font-size:24px;font-size:1.5rem;line-height:1.25}}@media print{.moj-filter__legend button{font-size:18pt;line-height:1.15}}.moj-filter__legend button::-moz-focus-inner{border:0;padding:0}.moj-filter__legend button:after{background-image:url(/assets/images/icon-toggle-plus-minus.svg);background-position:0 0;content:"";display:block;height:16px;margin-top:-8px;position:absolute;right:0;top:50%;width:16px}.moj-filter__legend button[aria-expanded=true]:after{background-position:16px 16px}.moj-filter__header-action,.moj-filter__header-title{display:inline-block;text-align:left;vertical-align:middle}.moj-filter__close{-webkit-appearance:none;background-color:transparent;border:none;border-radius:0;color:#0b0c0c;cursor:pointer;margin:0;padding:0}.moj-filter__close:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none}.moj-filter__close::-moz-focus-inner{border:0;padding:0}.moj-filter__close:before{background-image:url(/assets/images/icon-close-cross-black.svg);content:"";display:inline-block;height:14px;margin-right:5px;position:relative;top:-1px;vertical-align:middle;width:14px}.moj-filter__close{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25}@media print{.moj-filter__close{font-family:sans-serif}}@media (min-width:40.0625em){.moj-filter__close{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-filter__close{font-size:14pt;line-height:1.15}}.moj-filter__selected{background-color:#f3f2f1;box-shadow:inset 0 0 0 1px #b1b4b6;padding:20px}.moj-filter__selected ul:last-of-type{margin-bottom:0}.moj-filter__selected-heading{font-size:0;text-align:justify}.moj-filter__selected-heading:after{content:"";display:inline-block;width:100%}.moj-filter__heading-action,.moj-filter__heading-title{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;line-height:1.1428571429;text-align:left;vertical-align:middle}@media print{.moj-filter__heading-action,.moj-filter__heading-title{font-family:sans-serif}}@media (min-width:40.0625em){.moj-filter__heading-action,.moj-filter__heading-title{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-filter__heading-action,.moj-filter__heading-title{font-size:14pt;line-height:1.2}}.moj-filter-tags{font-size:0;margin-bottom:20px;padding-left:0}.moj-filter-tags li{display:inline-block;margin-right:10px}.moj-filter__tag{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#fff;border:1px solid #0b0c0c;color:#0b0c0c;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;line-height:1.1428571429;margin-top:5px;padding:5px;text-decoration:none}@media print{.moj-filter__tag{font-family:sans-serif}}@media (min-width:40.0625em){.moj-filter__tag{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-filter__tag{font-size:14pt;line-height:1.2}}.moj-filter__tag:link,.moj-filter__tag:visited{color:#0b0c0c}.moj-filter__tag:focus{background-color:#fd0;color:#0b0c0c}.moj-filter__tag:hover{background-color:#0b0c0c;color:#fff}.moj-filter__tag:after{background-image:url(/assets/images/icon-tag-remove-cross.svg);content:"";display:inline-block;font-weight:700;height:10px;margin-left:5px;vertical-align:middle;width:10px}.moj-filter__tag:hover:after{background-image:url(/assets/images/icon-tag-remove-cross-white.svg)}.moj-filter__options{box-shadow:inset 0 0 0 1px #b1b4b6;margin-top:-1px;padding:20px}.moj-filter__options div:last-of-type{margin-bottom:0}.moj-header{background-color:#0b0c0c;border-bottom:10px solid #1d70b8;padding-top:15px}.moj-header__container{margin:0 15px;max-width:960px;position:relative}@media (min-width:40.0625em){.moj-header__container{margin:0 30px}}@media (min-width:1020px){.moj-header__container{margin:0 auto}}.moj-header__container:after{clear:both;content:"";display:block}.moj-header__logo{padding-bottom:5px}@media (min-width:48.0625em){.moj-header__logo{float:left}}.moj-header__logotype-crown{margin-right:5px;position:relative;top:-4px;vertical-align:top}.moj-header__logotype-crest{margin-right:5px;position:relative;top:-6px;vertical-align:top}.moj-header__content{padding-bottom:10px}@media (min-width:48.0625em){.moj-header__content{float:right}}.moj-header__link,.moj-header__link>a{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;border-bottom:1px solid transparent;color:#fff;display:inline-block;font-family:GDS Transport,arial,sans-serif;line-height:25px;margin-bottom:-1px;overflow:hidden;text-decoration:underline;text-decoration:none;vertical-align:middle}@media print{.moj-header__link,.moj-header__link>a{font-family:sans-serif}}.moj-header__link:focus,.moj-header__link>a:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-header__link:link,.moj-header__link>a:link{color:#1d70b8}.moj-header__link:visited,.moj-header__link>a:visited{color:#4c2c92}.moj-header__link:hover,.moj-header__link>a:hover{color:#003078}.moj-header__link:active,.moj-header__link>a:active{color:#0b0c0c}.moj-header__link:active,.moj-header__link:hover,.moj-header__link:link,.moj-header__link:visited,.moj-header__link>a:active,.moj-header__link>a:hover,.moj-header__link>a:link,.moj-header__link>a:visited{color:#fff}.moj-header__link:hover,.moj-header__link>a:hover{border-color:#fff}.moj-header__link:focus,.moj-header__link>a:focus{border-color:transparent;color:#0b0c0c}.moj-header__link--organisation-name,.moj-header__link>a--organisation-name{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:18px;font-size:1.125rem;font-weight:700;line-height:1.1111111111;vertical-align:middle}@media print{.moj-header__link--organisation-name,.moj-header__link>a--organisation-name{font-family:sans-serif}}@media (min-width:40.0625em){.moj-header__link--organisation-name,.moj-header__link>a--organisation-name{font-size:24px;font-size:1.5rem;line-height:1.25}}@media print{.moj-header__link--organisation-name,.moj-header__link>a--organisation-name{font-size:18pt;line-height:1.15}}.moj-header__link--organisation-name:hover,.moj-header__link>a--organisation-name:hover{border-color:transparent}.moj-header__link--service-name,.moj-header__link>a--service-name{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:18px;font-size:1.125rem;line-height:1.1111111111;vertical-align:middle}@media print{.moj-header__link--service-name,.moj-header__link>a--service-name{font-family:sans-serif}}@media (min-width:40.0625em){.moj-header__link--service-name,.moj-header__link>a--service-name{font-size:24px;font-size:1.5rem;line-height:1.25}}@media print{.moj-header__link--service-name,.moj-header__link>a--service-name{font-size:18pt;line-height:1.15}}@media (max-width:48.0525em){.moj-header__link--service-name,.moj-header__link>a--service-name{display:block}}@media (min-width:48.0625em){.moj-header__link--service-name,.moj-header__link>a--service-name{margin-left:5px}}.moj-header__link--service-name:hover,.moj-header__link>a--service-name:hover{border-color:transparent}.moj-header__link a{margin-bottom:1px;vertical-align:text-bottom}.moj-header__link a:hover{border-color:#fff}@media (max-width:48.0525em){.moj-header__link a{margin-bottom:-1px;vertical-align:middle}}span.moj-header__link:hover{border-color:transparent}.moj-header__navigation{color:#fff;margin-top:3px}.moj-header__navigation-list{font-size:0;list-style:none;margin:0;padding:0}.moj-header__navigation-item{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-right:20px}@media print{.moj-header__navigation-item{font-family:sans-serif}}@media (min-width:40.0625em){.moj-header__navigation-item{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-header__navigation-item{font-size:14pt;line-height:1.15}}.moj-header__navigation-item:last-child{margin-right:0}.moj-header__navigation-link{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;text-decoration:underline}@media print{.moj-header__navigation-link{font-family:sans-serif}}.moj-header__navigation-link:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-header__navigation-link:link{color:#1d70b8}.moj-header__navigation-link:visited{color:#4c2c92}.moj-header__navigation-link:hover{color:#003078}.moj-header__navigation-link:active{color:#0b0c0c}.moj-header__navigation-link:active,.moj-header__navigation-link:link,.moj-header__navigation-link:visited{color:inherit;text-decoration:none}.moj-header__navigation-link:hover{text-decoration:underline!important}.moj-header__navigation-link:focus{color:#0b0c0c}.moj-header__navigation-link[aria-current=page]{text-decoration:none}.moj-identity-bar{background-color:#fff;box-shadow:inset 0 -1px 0 0 #b1b4b6;color:#0b0c0c;padding-bottom:9px;padding-top:10px}.moj-identity-bar:after{clear:both;content:"";display:block}.moj-identity-bar__container{font-size:0;margin:0 15px;max-width:960px;text-align:justify}@media (min-width:40.0625em){.moj-identity-bar__container{margin:0 30px}}@media (min-width:1020px){.moj-identity-bar__container{margin:0 auto}}.moj-identity-bar__container:after{content:"";display:inline-block;width:100%}.moj-identity-bar__title{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;line-height:1.1428571429;vertical-align:top}@media print{.moj-identity-bar__title{font-family:sans-serif}}@media (min-width:40.0625em){.moj-identity-bar__title{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-identity-bar__title{font-size:14pt;line-height:1.2}}.moj-identity-bar__details{margin-right:10px;padding-bottom:5px;padding-top:5px}@media (min-width:40.0625em){.moj-identity-bar__details{display:inline-block;padding-bottom:9px;padding-top:11px;vertical-align:top}}.moj-identity-bar__actions{margin-bottom:-10px}@media (min-width:40.0625em){.moj-identity-bar__actions{display:inline-block;vertical-align:middle}}.moj-identity-bar__menu{display:inline-block;margin-right:10px}.moj-identity-bar__menu:last-child{margin-right:0}.moj-messages-container{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;border:1px solid #b1b4b6;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25}@media print{.moj-messages-container{font-family:sans-serif}}@media (min-width:40.0625em){.moj-messages-container{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-messages-container{font-size:14pt;line-height:1.15}}.moj-message-list{min-height:200px;overflow-x:hidden;overflow-y:scroll;padding:5px}.moj-message-list__date{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#505a5f;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:700;line-height:1.25;padding:15px 0;text-align:center;width:100%}@media print{.moj-message-list__date{font-family:sans-serif}}@media (min-width:40.0625em){.moj-message-list__date{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-message-list__date{font-size:14pt;line-height:1.15}}.moj-message-item{border-radius:.5em .5em .75em .5em;margin-bottom:5px;padding:15px;position:relative}@media (min-width:40.0625em){.moj-message-item{width:50%}}.moj-message-item--sent{background-color:#1d70b8;color:#fff;float:right;margin-right:10px;padding-right:25px;text-align:right}.moj-message-item--sent:after{border-bottom-left-radius:1.75em 1.5em;border-left:1em solid #1d70b8;bottom:0;content:"";height:1.5em;position:absolute;right:-1.5em;width:1.5em}.moj-message-item--received{background-color:#f3f2f1;float:left;margin-left:10px;padding-left:25px}.moj-message-item--received:after{border-bottom-right-radius:1.75em 1.5em;border-right:1em solid #f3f2f1;bottom:0;content:"";height:1.5em;left:-1.5em;position:absolute;width:1.5em}.moj-message-item a:link,.moj-message-item a:visited{color:#fff}.moj-message-item a:focus{color:#0b0c0c}.moj-message-item__text--sent table{color:#fff}.moj-message-item__text--sent table td,.moj-message-item__text--sent table th{border-bottom:1px solid #fff}.moj-message-item__meta{margin-top:10px}.moj-message-item__meta--sender{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.1428571429}@media print{.moj-message-item__meta--sender{font-family:sans-serif}}@media (min-width:40.0625em){.moj-message-item__meta--sender{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-message-item__meta--sender{font-size:14pt;line-height:1.2}}.moj-message-item__meta--timestamp{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:700;line-height:1.1428571429}@media print{.moj-message-item__meta--timestamp{font-family:sans-serif}}@media (min-width:40.0625em){.moj-message-item__meta--timestamp{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-message-item__meta--timestamp{font-size:14pt;line-height:1.2}}.moj-multi-file-upload{margin-bottom:40px}.moj-multi-file-upload--enhanced .moj-multi-file-upload__button{display:none}.moj-multi-file-upload__dropzone{display:flex;outline:3px dashed #0b0c0c;padding:60px 15px;text-align:center;transition:outline-offset .1s ease-in-out,background-color .1s linear}.moj-multi-file-upload__dropzone label{display:inline-block;margin-bottom:0;width:auto}.moj-multi-file-upload__dropzone p{margin-bottom:0;margin-right:10px;padding-top:7px}.moj-multi-file-upload__dropzone [type=file]{left:-9999em;position:absolute}.moj-multi-file-upload--dragover{background:#b1b4b6;outline-color:#6f777b}.moj-multi-file-upload--focused{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none}.moj-multi-file-upload__error{color:#d4351c;font-weight:700}.moj-multi-file-upload__success{color:#00703c;font-weight:700}.moj-multi-file-upload__error svg,.moj-multi-file-upload__success svg{fill:currentColor;float:left;margin-right:10px}.moj-multi-select__checkbox{display:inline-block;padding-left:0}.moj-multi-select__toggle-label{margin:0!important;padding:0!important}.moj-notification-badge{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;background-color:#d4351c;border-radius:75px;color:#fff;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-size:16px;font-weight:700;font-weight:600;line-height:1.1428571429;min-width:15px;padding:5px 8px 2px;text-align:center;white-space:nowrap}@media print{.moj-notification-badge{font-family:sans-serif}}@media (min-width:40.0625em){.moj-notification-badge{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-notification-badge{font-size:14pt;line-height:1.2}}.moj-organisation-nav{border-bottom:1px solid #b1b4b6;margin-bottom:15px;margin-top:10px;padding-bottom:5px}.moj-organisation-nav:after{clear:both;content:"";display:block}.moj-organisation-nav__title{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:700;line-height:1.25}@media print{.moj-organisation-nav__title{font-family:sans-serif}}@media (min-width:40.0625em){.moj-organisation-nav__title{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-organisation-nav__title{font-size:14pt;line-height:1.15}}@media (min-width:40.0625em){.moj-organisation-nav__title{float:left;width:75%}}.moj-organisation-nav__link{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;text-decoration:underline}@media print{.moj-organisation-nav__link{font-family:sans-serif}}.moj-organisation-nav__link:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-organisation-nav__link:link{color:#1d70b8}.moj-organisation-nav__link:visited{color:#4c2c92}.moj-organisation-nav__link:hover{color:#003078}.moj-organisation-nav__link:active,.moj-organisation-nav__link:focus{color:#0b0c0c}@media print{.moj-organisation-nav__link[href^="/"]:after,.moj-organisation-nav__link[href^="http://"]:after,.moj-organisation-nav__link[href^="https://"]:after{word-wrap:break-word;content:" (" attr(href) ")";font-size:90%}}@media (min-width:40.0625em){.moj-organisation-nav__link{float:right}}.moj-page-header-actions{font-size:0;margin-bottom:40px;min-height:40px;text-align:justify}.moj-page-header-actions:after{clear:both;content:"";display:block;display:inline-block;width:100%}.moj-page-header-actions__title [class^=govuk-heading-]{margin-bottom:10px;text-align:left}@media (min-width:40.0625em){.moj-page-header-actions__title [class^=govuk-heading-]{margin-bottom:0}.moj-page-header-actions__actions,.moj-page-header-actions__title{display:inline-block;vertical-align:middle}}.moj-page-header-actions__action:last-child{margin-bottom:0}@media (min-width:40.0625em){.moj-page-header-actions__action{margin-bottom:0}}@media (min-width:48.0625em){.moj-pagination{font-size:0;margin-left:-5px;margin-right:-5px;text-align:justify}.moj-pagination:after{content:"";display:inline-block;width:100%}}.moj-pagination__list{list-style:none;margin:0;padding:0}@media (min-width:48.0625em){.moj-pagination__list{display:inline-block;margin-bottom:0;vertical-align:middle}}.moj-pagination__results{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-top:0}@media print{.moj-pagination__results{font-family:sans-serif}}@media (min-width:40.0625em){.moj-pagination__results{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-pagination__results{font-size:14pt;line-height:1.15}}@media (min-width:48.0625em){.moj-pagination__results{display:inline-block;margin-bottom:0;vertical-align:middle}}.moj-pagination__item{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25}@media print{.moj-pagination__item{font-family:sans-serif}}@media (min-width:40.0625em){.moj-pagination__item{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-pagination__item{font-size:14pt;line-height:1.15}}.moj-pagination__item--active,.moj-pagination__item--dots{font-weight:700;height:25px;padding:5px 10px;text-align:center}.moj-pagination__item--dots{padding-left:0;padding-right:0}.moj-pagination__item--next .moj-pagination__link:after,.moj-pagination__item--prev .moj-pagination__link:before{background:transparent;border-style:solid;color:#0b0c0c;content:"";display:inline-block;height:10px;transform:rotate(-45deg);width:10px}.moj-pagination__item--prev .moj-pagination__link:before{border-width:3px 0 0 3px;margin-right:5px}.moj-pagination__item--next .moj-pagination__link:after{border-width:0 3px 3px 0;margin-left:5px}.moj-pagination__link{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:block;font-family:GDS Transport,arial,sans-serif;min-width:25px;padding:5px;text-align:center;text-decoration:underline;text-decoration:none}@media print{.moj-pagination__link{font-family:sans-serif}}.moj-pagination__link:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-pagination__link:link{color:#1d70b8}.moj-pagination__link:visited{color:#4c2c92}.moj-pagination__link:hover{color:#003078}.moj-pagination__link:active{color:#0b0c0c}.moj-pagination__link:link,.moj-pagination__link:visited{color:#1d70b8}.moj-pagination__link:hover{color:#5694ca}.moj-pagination__link:focus{color:#0b0c0c}.moj-pagination__results{padding:5px}.moj-password-reveal{display:flex}.moj-password-reveal__input{margin-right:5px}.moj-password-reveal__button{width:80px}.moj-primary-navigation{background-color:#f3f2f1}.moj-primary-navigation__container{font-size:0;margin:0 15px;max-width:960px;text-align:justify}@media (min-width:40.0625em){.moj-primary-navigation__container{margin:0 30px}}@media (min-width:1020px){.moj-primary-navigation__container{margin:0 auto}}.moj-primary-navigation__container:after{content:"";display:inline-block;width:100%}.moj-primary-navigation__nav{text-align:left}@media (min-width:48.0625em){.moj-primary-navigation__nav{display:inline-block;vertical-align:middle}}.moj-primary-navigation__list{font-size:0;list-style:none;margin:0;padding:0}.moj-primary-navigation__item{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-right:20px;margin-top:0}@media print{.moj-primary-navigation__item{font-family:sans-serif}}@media (min-width:40.0625em){.moj-primary-navigation__item{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-primary-navigation__item{font-size:14pt;line-height:1.15}}.moj-primary-navigation__item:last-child{margin-right:0}.moj-primary-navigation__link{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:block;font-family:GDS Transport,arial,sans-serif;font-weight:700;padding-bottom:15px;padding-top:15px;text-decoration:underline;text-decoration:none}@media print{.moj-primary-navigation__link{font-family:sans-serif}}.moj-primary-navigation__link:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-primary-navigation__link:link{color:#1d70b8}.moj-primary-navigation__link:visited{color:#4c2c92}.moj-primary-navigation__link:hover{color:#003078}.moj-primary-navigation__link:active{color:#0b0c0c}.moj-primary-navigation__link:link,.moj-primary-navigation__link:visited{color:#1d70b8}.moj-primary-navigation__link:hover{color:#5694ca}.moj-primary-navigation__link:focus{box-shadow:none;color:#0b0c0c;position:relative;z-index:1}.moj-primary-navigation__link:focus:before{background-color:#0b0c0c;bottom:0;content:"";display:block;height:5px;left:0;position:absolute;width:100%}.moj-primary-navigation__link[aria-current]{color:#1d70b8;font-weight:700;position:relative;text-decoration:none}.moj-primary-navigation__link[aria-current]:before{background-color:#1d70b8;bottom:0;content:"";display:block;height:5px;left:0;position:absolute;width:100%}.moj-primary-navigation__link[aria-current]:focus{border:none;color:#0b0c0c;position:relative}.moj-primary-navigation__link[aria-current]:focus:before{background-color:#0b0c0c}@media (min-width:48.0625em){.moj-primary-navigation__search{display:inline-block;vertical-align:middle}}.moj-progress-bar{margin-bottom:40px}.moj-progress-bar__list{font-size:0;list-style:none;margin:0;padding:0;position:relative;text-align:justify;vertical-align:top}.moj-progress-bar__list:after{content:"";display:inline-block;width:100%}.moj-progress-bar__list:before{border-top:6px solid #00703c;content:"";left:0;position:absolute;top:13px;width:100%}.moj-progress-bar__item{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;max-width:20%;position:relative;text-align:center;vertical-align:top}@media print{.moj-progress-bar__item{font-family:sans-serif}}@media (min-width:40.0625em){.moj-progress-bar__item{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-progress-bar__item{font-size:14pt;line-height:1.15}}.moj-progress-bar__item:first-child:before,.moj-progress-bar__item:last-child:before{border-top:6px solid #fff;content:"";left:0;position:absolute;top:13px;width:50%}.moj-progress-bar__item:first-child:before{left:0}.moj-progress-bar__item:last-child:before{left:auto;right:0}.moj-progress-bar__item[aria-current=step]{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:700;line-height:1.25}@media print{.moj-progress-bar__item[aria-current=step]{font-family:sans-serif}}@media (min-width:40.0625em){.moj-progress-bar__item[aria-current=step]{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-progress-bar__item[aria-current=step]{font-size:14pt;line-height:1.15}}.moj-progress-bar__icon{background-color:#fff;border:6px solid #00703c;border-radius:50%;box-sizing:border-box;display:block;height:32px;margin-left:auto;margin-right:auto;position:relative;width:32px}.moj-progress-bar__icon--complete{background-color:#00703c;background-image:url(/assets/images/icon-progress-tick.svg);background-position:50% 50%;background-repeat:no-repeat}.moj-progress-bar__label{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;word-wrap:break-word;display:block;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;font-weight:inherit;line-height:1.1428571429;margin-top:15px;position:relative}@media print{.moj-progress-bar__label{font-family:sans-serif}}@media (min-width:40.0625em){.moj-progress-bar__label{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-progress-bar__label{font-size:14pt;line-height:1.2}}.moj-rich-text-editor__toolbar{margin-bottom:10px}.moj-rich-text-editor__toolbar:after{clear:both;content:"";display:block}.moj-rich-text-editor__toolbar-button{background-color:#fff;background-position:50% 50%;background-repeat:no-repeat;background-size:40px 40px;border:2px solid #0b0c0c;color:#0b0c0c;cursor:pointer;float:left;height:40px;margin-left:-2px;outline:0;text-decoration:none;vertical-align:top;width:40px}.moj-rich-text-editor__toolbar-button:first-child{margin-left:0}.moj-rich-text-editor__toolbar-button::-moz-focus-inner{border:0;padding:0}.moj-rich-text-editor__toolbar-button:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none;position:relative;z-index:2}.moj-rich-text-editor__toolbar-button--bold{background-image:url(/assets/images/icon-wysiwyg-bold.svg)}.moj-rich-text-editor__toolbar-button--italic{background-image:url(/assets/images/icon-wysiwyg-italic.svg)}.moj-rich-text-editor__toolbar-button--underline{background-image:url(/assets/images/icon-wysiwyg-underline.svg)}.moj-rich-text-editor__toolbar-button--unordered-list{background-image:url(/assets/images/icon-wysiwyg-unordered-list.svg);margin-left:10px}.moj-rich-text-editor__toolbar-button--ordered-list{background-image:url(/assets/images/icon-wysiwyg-ordered-list.svg)}.moj-rich-text-editor__content{min-height:130px;outline:none;overflow:auto;resize:vertical}.moj-search-toggle__button{-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased;-webkit-appearance:none;background-color:transparent;border:none;color:#1d70b8;cursor:pointer;display:inline-block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:700;line-height:1.25;padding:12px 0 13px}@media print{.moj-search-toggle__button{font-family:sans-serif}}@media (min-width:40.0625em){.moj-search-toggle__button{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-search-toggle__button{font-size:14pt;line-height:1.15}}.moj-search-toggle__button__icon{fill:currentColor;display:inline-block;height:20px;margin-left:10px;vertical-align:middle;width:20px}@media screen and (forced-colors:active){.moj-search-toggle__button__icon{fill:windowText}}.moj-search-toggle__button:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none;position:relative;z-index:1}.moj-search--toggle{padding:15px}@media (max-width:48.0525em){.moj-search--toggle{padding-left:0!important;padding-right:0!important}.js-enabled .moj-search--toggle{padding-top:0!important}}.js-enabled .moj-search-toggle{position:relative}.js-enabled .moj-search-toggle__search{background-color:#f3f2f1}@media (min-width:48.0625em){.js-enabled .moj-search-toggle__search{max-width:450px;position:absolute;right:-15px;top:50px;width:450px;z-index:10}}.moj-search{font-size:0}.moj-search form{align-items:flex-end;display:flex}.moj-search .govuk-form-group{display:inline-block;flex:1;margin-bottom:0;vertical-align:top}.moj-search__hint,.moj-search__label{text-align:left}.moj-search__input:focus{position:relative;z-index:1}.moj-search__button{display:inline-block;margin-bottom:0;margin-left:10px;position:relative;top:-2px;vertical-align:bottom;width:auto}.moj-search--inline{padding:10px 0!important}@media (min-width:48.0625em){.moj-search--inline{padding:0!important}}.moj-side-navigation{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;line-height:1.1428571429}@media print{.moj-side-navigation{font-family:sans-serif}}@media (min-width:40.0625em){.moj-side-navigation{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-side-navigation{font-size:14pt;line-height:1.2}}@media (max-width:40.0525em){.moj-side-navigation{display:flex;overflow-x:scroll}}@media (min-width:40.0625em){.moj-side-navigation{display:block;padding:20px 0 0}}.moj-side-navigation__title{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#505a5f;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin:0;padding:10px 10px 10px 14px}@media print{.moj-side-navigation__title{font-family:sans-serif}}@media (min-width:40.0625em){.moj-side-navigation__title{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-side-navigation__title{font-size:14pt;line-height:1.15}}@media (max-width:40.0525em){.moj-side-navigation__title{display:none}}.moj-side-navigation__list{list-style:none;margin:0;padding:0}@media (max-width:40.0525em){.moj-side-navigation__list{display:flex;margin:0;white-space:nowrap}}@media (min-width:40.0625em){.moj-side-navigation__list{margin-bottom:20px}}@media (max-width:40.0525em){.moj-side-navigation__item{display:flex}}.moj-side-navigation__item a,.moj-side-navigation__item a:link,.moj-side-navigation__item a:visited{background-color:inherit;color:#1d70b8;display:block;text-decoration:none}@media (max-width:40.0525em){.moj-side-navigation__item a,.moj-side-navigation__item a:link,.moj-side-navigation__item a:visited{border-bottom:4px solid transparent;padding:15px 15px 11px}}@media (min-width:40.0625em){.moj-side-navigation__item a,.moj-side-navigation__item a:link,.moj-side-navigation__item a:visited{background-color:inherit;border-left:4px solid transparent;padding:10px}}.moj-side-navigation__item a:hover{border-color:#5694ca}.moj-side-navigation__item a:focus{background-color:#fd0;border-color:#0b0c0c #0b0c0c #0b0c0c transparent;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;position:relative}.moj-side-navigation__item--active a:link,.moj-side-navigation__item--active a:visited{border-color:#1d70b8;color:#1d70b8;font-weight:700}.moj-side-navigation__item--active a:focus{background-color:#fd0;border-color:#0b0c0c #0b0c0c #0b0c0c transparent;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c}@media (min-width:40.0625em){.moj-side-navigation__item--active a:link,.moj-side-navigation__item--active a:visited{background-color:#f3f2f1}.moj-side-navigation__item--active a:focus{background-color:#fd0;border-color:transparent;color:#0b0c0c}}[aria-sort] button,[aria-sort] button:hover{background-color:transparent;border-width:0;box-shadow:0 0 0 0;color:#005ea5;cursor:pointer;font-family:inherit;font-size:inherit;font-size:1em;font-weight:inherit;margin:0;padding:0 10px 0 0;position:relative;text-align:inherit}[aria-sort] button:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;color:#0b0c0c;outline:none}[aria-sort]:first-child button{right:auto}[aria-sort] button:before{content:" ▼";font-size:.5em;position:absolute;right:-1px;top:9px}[aria-sort] button:after{content:" ▲";font-size:.5em;position:absolute;right:-1px;top:1px}[aria-sort=ascending] button:before,[aria-sort=descending] button:before{content:none}[aria-sort=ascending] button:after{content:" ▲";font-size:.8em;position:absolute;right:-5px;top:2px}[aria-sort=descending] button:after{content:" ▼";font-size:.8em;position:absolute;right:-5px;top:2px}.moj-sub-navigation{margin-bottom:40px}.moj-sub-navigation__list{font-size:0;list-style:none;margin:0;padding:0}@media (min-width:40.0625em){.moj-sub-navigation__list{box-shadow:inset 0 -1px 0 #b1b4b6;width:100%}}.moj-sub-navigation__item{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;box-shadow:inset 0 -1px 0 #b1b4b6;display:block;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-top:-1px}@media print{.moj-sub-navigation__item{font-family:sans-serif}}@media (min-width:40.0625em){.moj-sub-navigation__item{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-sub-navigation__item{font-size:14pt;line-height:1.15}}.moj-sub-navigation__item:last-child{box-shadow:none}@media (min-width:40.0625em){.moj-sub-navigation__item{box-shadow:none;display:inline-block;margin-right:20px;margin-top:0}}.moj-sub-navigation__link{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:block;font-family:GDS Transport,arial,sans-serif;padding-bottom:12px;padding-left:15px;padding-top:12px;position:relative;text-decoration:underline;text-decoration:none}@media print{.moj-sub-navigation__link{font-family:sans-serif}}.moj-sub-navigation__link:focus{background-color:#fd0;box-shadow:0 -2px #fd0,0 4px #0b0c0c;outline:3px solid transparent;text-decoration:none}.moj-sub-navigation__link:link{color:#1d70b8}.moj-sub-navigation__link:visited{color:#4c2c92}.moj-sub-navigation__link:hover{color:#003078}.moj-sub-navigation__link:active{color:#0b0c0c}@media (min-width:40.0625em){.moj-sub-navigation__link{padding-left:0}}.moj-sub-navigation__link:link,.moj-sub-navigation__link:visited{color:#1d70b8}.moj-sub-navigation__link:hover{color:#5694ca}.moj-sub-navigation__link:focus{box-shadow:none;color:#0b0c0c;position:relative}.moj-sub-navigation__link:focus:before{background-color:#0b0c0c;bottom:0;content:"";display:block;height:5px;left:0;position:absolute;right:0;width:100%}.moj-sub-navigation__link[aria-current=page]{color:#0b0c0c;position:relative;text-decoration:none}.moj-sub-navigation__link[aria-current=page]:before{background-color:#1d70b8;bottom:0;content:"";display:block;height:100%;left:0;position:absolute;width:5px}@media (min-width:40.0625em){.moj-sub-navigation__link[aria-current=page]:before{height:5px;width:100%}}.moj-sub-navigation__link[aria-current=page]:focus:before{background-color:#0b0c0c}.moj-tag{background-color:#1d70b8;border:2px solid #1d70b8;color:#fff}.moj-tag--purple{background-color:#4c2c92;border:2px solid #4c2c92;color:#fff}.moj-tag--bright-purple{background-color:#912b88;border:2px solid #912b88;color:#fff}.moj-tag--error,.moj-tag--red{background-color:#d4351c;border:2px solid #d4351c;color:#fff}.moj-tag--green,.moj-tag--success{background-color:#00703c;border:2px solid #00703c;color:#fff}.moj-tag--blue,.moj-tag--information{background-color:#1d70b8;border:2px solid #1d70b8;color:#fff}.moj-tag--black{background-color:#0b0c0c;border:2px solid #0b0c0c;color:#fff}.moj-tag--grey{background-color:#505a5f;border:2px solid #505a5f;color:#fff}.moj-task-list{list-style-type:none;margin-bottom:0;margin-top:0;padding-left:0}@media (min-width:40.0625em){.moj-task-list{min-width:550px}}.moj-task-list__section{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:table;font-family:GDS Transport,arial,sans-serif;font-size:18px;font-size:1.125rem;font-weight:700;line-height:1.1111111111}@media print{.moj-task-list__section{font-family:sans-serif}}@media (min-width:40.0625em){.moj-task-list__section{font-size:24px;font-size:1.5rem;line-height:1.25}}@media print{.moj-task-list__section{font-size:18pt;line-height:1.15}}.moj-task-list__section-number{display:table-cell}@media (min-width:40.0625em){.moj-task-list__section-number{min-width:30px;padding-right:0}}.moj-task-list__items{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;list-style:none;margin-bottom:40px;padding-left:0}@media print{.moj-task-list__items{font-family:sans-serif}}@media (min-width:40.0625em){.moj-task-list__items{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-task-list__items{font-size:14pt;line-height:1.15}}@media (min-width:40.0625em){.moj-task-list__items{margin-bottom:60px;padding-left:30px}}.moj-task-list__item{border-bottom:1px solid #b1b4b6;margin-bottom:0!important;padding-bottom:10px;padding-top:10px}.moj-task-list__item:after{clear:both;content:"";display:block}.moj-task-list__item:first-child{border-top:1px solid #b1b4b6}.moj-task-list__task-name{display:block}@media (min-width:28.125em){.moj-task-list__task-name{float:left;width:75%}}.moj-task-list__task-completed{margin-bottom:5px;margin-top:10px}@media (min-width:28.125em){.moj-task-list__task-completed{float:right;margin-bottom:0;margin-top:0}}.moj-timeline{margin-bottom:20px;overflow:hidden;position:relative}.moj-timeline:before{background-color:#1d70b8;content:"";height:100%;left:0;position:absolute;top:10px;width:5px}.moj-timeline--full{margin-bottom:0}.moj-timeline--full:before{height:calc(100% - 75px)}.moj-timeline__item{padding-bottom:30px;padding-left:20px;position:relative}.moj-timeline__item:before{background-color:#1d70b8;content:"";height:5px;left:0;position:absolute;top:10px;width:15px}.moj-timeline__title{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;display:inline;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:700;line-height:1.25}@media print{.moj-timeline__title{font-family:sans-serif}}@media (min-width:40.0625em){.moj-timeline__title{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-timeline__title{font-size:14pt;line-height:1.15}}.moj-timeline__byline{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;color:#505a5f;display:inline;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin:0}@media print{.moj-timeline__byline{font-family:sans-serif}}@media (min-width:40.0625em){.moj-timeline__byline{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-timeline__byline{font-size:14pt;line-height:1.15}}.moj-timeline__date{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:14px;font-size:.875rem;font-weight:400;line-height:1.1428571429;margin-bottom:0;margin-top:5px}@media print{.moj-timeline__date{font-family:sans-serif}}@media (min-width:40.0625em){.moj-timeline__date{font-size:16px;font-size:1rem;line-height:1.25}}@media print{.moj-timeline__date{font-size:14pt;line-height:1.2}}.moj-timeline__description{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-family:GDS Transport,arial,sans-serif;font-size:16px;font-size:1rem;font-weight:400;line-height:1.25;margin-top:20px}@media print{.moj-timeline__description{font-family:sans-serif}}@media (min-width:40.0625em){.moj-timeline__description{font-size:19px;font-size:1.1875rem;line-height:1.3157894737}}@media print{.moj-timeline__description{font-size:14pt;line-height:1.15}}.moj-timeline__documents{list-style:none;margin-bottom:0;padding-left:0}.moj-timeline__document-item{margin-bottom:5px}.moj-timeline__document-item:last-child{margin-bottom:0}.moj-timeline__document-icon{fill:currentColor;float:left;margin-right:4px;margin-top:4px}@media screen and (forced-colors:active){.moj-timeline__document-icon{fill:linkText}}.moj-timeline__document-link{background-image:url(/assets/images/icon-document.svg);background-position:0 50%;background-repeat:no-repeat;background-size:20px 16px;padding-left:25px}.moj-timeline__document-link:focus{color:#0b0c0c}.moj-ticket-panel{display:block;flex-wrap:wrap;margin-right:0}@media (min-width:48.0625em){.moj-ticket-panel--inline{display:flex;flex-wrap:nowrap}.moj-ticket-panel--inline>*+*{margin-left:15px}}.moj-ticket-panel__content :last-child{margin-bottom:0}.moj-ticket-panel__content{background-color:#f3f2f1;border-left:4px solid transparent;display:block;flex-grow:1;margin-bottom:15px;padding:20px;position:relative}.moj-ticket-panel__content--grey{border-left-color:#b1b4b6}.moj-ticket-panel__content--blue{border-left-color:#1d70b8}.moj-ticket-panel__content--red{border-left-color:#d4351c}.moj-ticket-panel__content--yellow{border-left-color:#fd0}.moj-ticket-panel__content--green{border-left-color:#00703c}.moj-ticket-panel__content--purple{border-left-color:#4c2c92}.moj-ticket-panel__content--orange{border-left-color:#f47738}.js-enabled .moj-js-hidden,.moj-hidden{display:none}.moj-width-container{margin:0 15px;max-width:960px}@media (min-width:40.0625em){.moj-width-container{margin:0 30px}}@media (min-width:1020px){.moj-width-container{margin:0 auto}}
+@charset "UTF-8";
+
+.moj-filter-layout:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-filter-layout__filter {
+	box-shadow: inset 0 0 0 1px #f3f2f1
+}
+
+@media (min-width:48.0625em) {
+	.moj-filter-layout__filter {
+		float: left;
+		margin-right: 40px;
+		max-width: 385px;
+		min-width: 260px;
+		width: 100%
+	}
+}
+
+@media (max-width:48.0525em) {
+	.js-enabled .moj-filter-layout__filter {
+		background-color: #fff;
+		bottom: 0;
+		overflow-y: scroll;
+		position: fixed;
+		right: 0;
+		top: 0;
+		z-index: 100
+	}
+}
+
+.moj-filter-layout__content {
+	overflow: hidden;
+	overflow-x: auto
+}
+
+@media (max-width:63.75em) {
+	.moj-scrollable-pane {
+		clear: both;
+		overflow: hidden;
+		position: relative
+	}
+
+	.moj-scrollable-pane:after {
+		border-radius: 10px 0 0 10px/50% 0 0 50%;
+		box-shadow: -5px 0 10px rgba(0, 0, 0, .25);
+		content: "";
+		height: 100%;
+		left: 100%;
+		position: absolute;
+		top: 0;
+		width: 50px
+	}
+
+	.moj-scrollable-pane__wrapper {
+		overflow-x: auto
+	}
+
+	.moj-scrollable-pane__wrapper .govuk-table__cell,
+	.moj-scrollable-pane__wrapper .govuk-table__header {
+		white-space: nowrap
+	}
+}
+
+@media (max-width:63.75em) {
+	.moj-scrollable-pane>div::-webkit-scrollbar {
+		height: 10px
+	}
+
+	.moj-scrollable-pane>div::-webkit-scrollbar-track {
+		background: #f3f2f1;
+		box-shadow: inset 0 0 2px rgba(0, 0, 0, .15)
+	}
+
+	.moj-scrollable-pane>div::-webkit-scrollbar-thumb {
+		background: #505a5f;
+		border-radius: 5px
+	}
+}
+
+.moj-action-bar {
+	font-size: 0
+}
+
+.moj-action-bar__filter {
+	display: inline-block;
+	position: relative
+}
+
+@media (max-width:48.0525em) {
+	.moj-action-bar__filter {
+		float: right
+	}
+}
+
+@media (min-width:48.0625em) {
+	.moj-action-bar__filter {
+		margin-right: 10px;
+		padding-right: 12px
+	}
+
+	.moj-action-bar__filter:after {
+		background-color: #f3f2f1;
+		content: "";
+		height: 40px;
+		position: absolute;
+		right: 0;
+		top: 0;
+		width: 2px
+	}
+}
+
+.moj-add-another__item {
+	margin: 30px 0 0;
+	padding: 0;
+	position: relative
+}
+
+.moj-add-another__item:first-of-type {
+	margin-top: 0
+}
+
+.moj-add-another__title {
+	float: left;
+	padding: 4px 100px 4px 0;
+	width: 100%
+}
+
+.moj-add-another__title+.govuk-form-group {
+	clear: left
+}
+
+.moj-add-another__remove-button {
+	position: absolute;
+	right: 0;
+	top: 0;
+	width: auto
+}
+
+.moj-add-another__add-button {
+	display: block
+}
+
+.moj-add-another__heading:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none
+}
+
+.moj-badge {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	border: 2px solid #1d70b8;
+	color: #1d70b8;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 12px;
+	font-size: .75rem;
+	font-weight: 700;
+	line-height: 1.25;
+	outline: 2px solid transparent;
+	outline-offset: -2px;
+	padding: 0 5px;
+	text-transform: uppercase;
+	vertical-align: middle
+}
+
+@media print {
+	.moj-badge {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-badge {
+		font-size: 14px;
+		font-size: .875rem;
+		line-height: 1.4285714286
+	}
+}
+
+@media print {
+	.moj-badge {
+		font-size: 12pt;
+		line-height: 1.2
+	}
+}
+
+.moj-badge--purple {
+	border-color: #4c2c92;
+	color: #4c2c92
+}
+
+.moj-badge--bright-purple {
+	border-color: #912b88;
+	color: #912b88
+}
+
+.moj-badge--red {
+	border-color: #d4351c;
+	color: #d4351c
+}
+
+.moj-badge--green {
+	border-color: #00703c;
+	color: #00703c
+}
+
+.moj-badge--blue {
+	border-color: #1d70b8;
+	color: #1d70b8
+}
+
+.moj-badge--black {
+	border-color: #0b0c0c;
+	color: #0b0c0c
+}
+
+.moj-badge--grey {
+	border-color: #505a5f;
+	color: #505a5f
+}
+
+.moj-badge--large {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 700;
+	line-height: 1.1428571429
+}
+
+@media print {
+	.moj-badge--large {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-badge--large {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-badge--large {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-banner {
+	border: 5px solid #1d70b8;
+	color: #1d70b8;
+	font-size: 0;
+	margin-bottom: 30px;
+	padding: 10px
+}
+
+.moj-banner__icon {
+	fill: currentColor;
+	float: left;
+	margin-right: 10px
+}
+
+.moj-banner__message {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #0b0c0c;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	overflow: hidden
+}
+
+@media print {
+	.moj-banner__message {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-banner__message {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-banner__message {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-banner__message h2 {
+	margin-bottom: 10px
+}
+
+.moj-banner__message h2:last-child,
+.moj-banner__message p:last-child {
+	margin-bottom: 0
+}
+
+.moj-banner__assistive {
+	clip: rect(0 0 0 0) !important;
+	border: 0 !important;
+	-webkit-clip-path: inset(50%) !important;
+	clip-path: inset(50%) !important;
+	height: 1px !important;
+	margin: 0 !important;
+	overflow: hidden !important;
+	padding: 0 !important;
+	position: absolute !important;
+	white-space: nowrap !important;
+	width: 1px !important
+}
+
+.moj-banner--success {
+	border-color: #00703c;
+	color: #00703c
+}
+
+.moj-banner--warning {
+	border-color: #d4351c;
+	color: #d4351c
+}
+
+.moj-button-menu {
+	display: inline-block;
+	position: relative
+}
+
+.moj-button-menu__toggle-button {
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-right: 10px;
+	width: auto
+}
+
+.moj-button-menu__toggle-button:last-child {
+	margin-right: 0
+}
+
+.moj-button-menu__toggle-button:after {
+	background-image: url(/assets/images/icon-arrow-white-down.svg);
+	background-repeat: no-repeat;
+	content: "";
+	display: inline-block;
+	height: 5px;
+	margin-left: 10px;
+	vertical-align: middle;
+	width: 10px
+}
+
+.moj-button-menu__toggle-button:focus:after {
+	background-image: url(/assets/images/icon-arrow-black-down.svg)
+}
+
+.moj-button-menu__toggle-button[aria-expanded=true]:focus:after {
+	background-image: url(/assets/images/icon-arrow-black-up.svg)
+}
+
+.moj-button-menu__toggle-button:hover:after {
+	background-image: url(/assets/images/icon-arrow-white-down.svg)
+}
+
+.moj-button-menu__toggle-button[aria-expanded=true]:after,
+.moj-button-menu__toggle-button[aria-expanded=true]:hover:after {
+	background-image: url(/assets/images/icon-arrow-white-up.svg)
+}
+
+.moj-button-menu__toggle-button--secondary {
+	margin-bottom: 5px;
+	margin-right: 0
+}
+
+.moj-button-menu__toggle-button--secondary:after {
+	background-image: url(/assets/images/icon-arrow-black-down.svg)
+}
+
+.moj-button-menu__toggle-button--secondary[aria-expanded=true]:after {
+	background-image: url(/assets/images/icon-arrow-black-up.svg)
+}
+
+.moj-button-menu__toggle-button--secondary:hover:after {
+	background-image: url(/assets/images/icon-arrow-black-down.svg)
+}
+
+.moj-button-menu__toggle-button--secondary[aria-expanded=true]:hover:after {
+	background-image: url(/assets/images/icon-arrow-black-up.svg)
+}
+
+.moj-button-menu__item {
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-right: 10px;
+	width: auto
+}
+
+.moj-button-menu__item:last-child {
+	margin-right: 0
+}
+
+.moj-button-menu [role=menuitem] {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-appearance: none;
+	background-color: #f3f2f1;
+	border: none;
+	box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-bottom: 0;
+	padding: 10px;
+	text-align: left;
+	width: 100%
+}
+
+@media print {
+	.moj-button-menu [role=menuitem] {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-button-menu [role=menuitem] {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-button-menu [role=menuitem] {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-button-menu [role=menuitem]:link,
+.moj-button-menu [role=menuitem]:visited {
+	color: #0b0c0c;
+	text-decoration: none
+}
+
+.moj-button-menu [role=menuitem]:hover {
+	background-color: #b1b4b6
+}
+
+.moj-button-menu [role=menuitem]:focus {
+	outline: 3px solid #fd0;
+	outline-offset: 0;
+	position: relative;
+	z-index: 10
+}
+
+.moj-button-menu__wrapper {
+	font-size: 0
+}
+
+.moj-button-menu__wrapper--right {
+	right: 0
+}
+
+.moj-button-menu [role=menu] {
+	position: absolute;
+	width: 200px;
+	z-index: 10
+}
+
+.moj-button-menu [aria-expanded=true]+[role=menu] {
+	display: block
+}
+
+.moj-button-menu [aria-expanded=false]+[role=menu] {
+	display: none
+}
+
+.govuk-width-container {
+	margin-left: 15px;
+	margin-right: 15px;
+	max-width: 960px
+}
+
+@supports (margin:max(calc(0px))) {
+	.govuk-width-container {
+		margin-left: max(15px, calc(15px + env(safe-area-inset-left)));
+		margin-right: max(15px, calc(15px + env(safe-area-inset-right)))
+	}
+}
+
+@media (min-width:40.0625em) {
+	.govuk-width-container {
+		margin-left: 30px;
+		margin-right: 30px
+	}
+
+	@supports (margin:max(calc(0px))) {
+		.govuk-width-container {
+			margin-left: max(30px, calc(15px + env(safe-area-inset-left)));
+			margin-right: max(30px, calc(15px + env(safe-area-inset-right)))
+		}
+	}
+}
+
+@media (min-width:1020px) {
+	.govuk-width-container {
+		margin-left: auto;
+		margin-right: auto
+	}
+
+	@supports (margin:max(calc(0px))) {
+		.govuk-width-container {
+			margin-left: auto;
+			margin-right: auto
+		}
+	}
+}
+
+.moj-cookie-banner {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	background-color: #fff;
+	box-sizing: border-box;
+	display: none;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	left: 15px;
+	line-height: 1.1428571429;
+	padding-bottom: 15px;
+	padding-right: 15px;
+	padding-top: 15px
+}
+
+@media print {
+	.moj-cookie-banner {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-cookie-banner {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-cookie-banner {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-cookie-banner--show {
+	display: block !important
+}
+
+.moj-cookie-banner__message {
+	margin: 0 15px;
+	max-width: 960px
+}
+
+@supports (margin:max(calc(0px))) {
+	.moj-cookie-banner__message {
+		margin-left: max(15px, calc(15px + env(safe-area-inset-left)));
+		margin-right: max(15px, calc(15px + env(safe-area-inset-right)))
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-cookie-banner__message {
+		margin-left: 30px;
+		margin-right: 30px
+	}
+
+	@supports (margin:max(calc(0px))) {
+		.moj-cookie-banner__message {
+			margin-left: max(30px, calc(15px + env(safe-area-inset-left)));
+			margin-right: max(30px, calc(15px + env(safe-area-inset-right)))
+		}
+	}
+}
+
+@media (min-width:1020px) {
+	.moj-cookie-banner__message {
+		margin-left: auto;
+		margin-right: auto
+	}
+
+	@supports (margin:max(calc(0px))) {
+		.moj-cookie-banner__message {
+			margin-left: auto;
+			margin-right: auto
+		}
+	}
+}
+
+.moj-cookie-banner__buttons .govuk-grid-column-full {
+	padding-left: 0
+}
+
+@media (min-width:40.0625em) {
+	.moj-cookie-banner .govuk-button {
+		width: 90%
+	}
+}
+
+@media print {
+	.moj-cookie-banner {
+		display: none !important
+	}
+}
+
+.moj-label__currency {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	background-color: #f3f2f1;
+	border-right: 2px solid #0b0c0c;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin: 2px 0 0 2px !important;
+	padding: 5.5px 12px;
+	position: absolute
+}
+
+@media print {
+	.moj-label__currency {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-label__currency {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-label__currency {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-label__currency--error {
+	background-color: #d4351c;
+	border-right: 2px solid #d4351c;
+	color: #fff
+}
+
+@media (max-width:40.0525em) {
+	.moj-label__currency {
+		padding: 8px 12px
+	}
+}
+
+.moj-input__currency {
+	margin: 0;
+	padding-left: 40px
+}
+
+.moj-filter {
+	background-color: #fff;
+	box-shadow: inset 0 0 0 1px #b1b4b6
+}
+
+.moj-filter:focus {
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c
+}
+
+.moj-filter__header {
+	background-color: #b1b4b6;
+	font-size: 0;
+	padding: 10px 20px;
+	text-align: justify
+}
+
+.moj-filter__header:after {
+	content: "";
+	display: inline-block;
+	width: 100%
+}
+
+.moj-filter__header [class^=govuk-heading-] {
+	margin-bottom: 0
+}
+
+.moj-filter__legend {
+	overflow: visible;
+	width: 100%
+}
+
+.moj-filter__legend button {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-appearance: none;
+	background-color: transparent;
+	border: 0;
+	border-radius: 0;
+	box-sizing: border-box;
+	cursor: pointer;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 18px;
+	font-size: 1.125rem;
+	font-weight: 700;
+	line-height: 1.1111111111;
+	margin: 0;
+	padding: 0;
+	position: relative;
+	text-align: left;
+	width: 100%
+}
+
+@media print {
+	.moj-filter__legend button {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-filter__legend button {
+		font-size: 24px;
+		font-size: 1.5rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-filter__legend button {
+		font-size: 18pt;
+		line-height: 1.15
+	}
+}
+
+.moj-filter__legend button::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+
+.moj-filter__legend button:after {
+	background-image: url(/assets/images/icon-toggle-plus-minus.svg);
+	background-position: 0 0;
+	content: "";
+	display: block;
+	height: 16px;
+	margin-top: -8px;
+	position: absolute;
+	right: 0;
+	top: 50%;
+	width: 16px
+}
+
+.moj-filter__legend button[aria-expanded=true]:after {
+	background-position: 16px 16px
+}
+
+.moj-filter__header-action,
+.moj-filter__header-title {
+	display: inline-block;
+	text-align: left;
+	vertical-align: middle
+}
+
+.moj-filter__close {
+	-webkit-appearance: none;
+	background-color: transparent;
+	border: none;
+	border-radius: 0;
+	color: #0b0c0c;
+	cursor: pointer;
+	margin: 0;
+	padding: 0
+}
+
+.moj-filter__close:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none
+}
+
+.moj-filter__close::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+
+.moj-filter__close:before {
+	background-image: url(/assets/images/icon-close-cross-black.svg);
+	content: "";
+	display: inline-block;
+	height: 14px;
+	margin-right: 5px;
+	position: relative;
+	top: -1px;
+	vertical-align: middle;
+	width: 14px
+}
+
+.moj-filter__close {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-filter__close {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-filter__close {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-filter__close {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-filter__selected {
+	background-color: #f3f2f1;
+	box-shadow: inset 0 0 0 1px #b1b4b6;
+	padding: 20px
+}
+
+.moj-filter__selected ul:last-of-type {
+	margin-bottom: 0
+}
+
+.moj-filter__selected-heading {
+	font-size: 0;
+	text-align: justify
+}
+
+.moj-filter__selected-heading:after {
+	content: "";
+	display: inline-block;
+	width: 100%
+}
+
+.moj-filter__heading-action,
+.moj-filter__heading-title {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	line-height: 1.1428571429;
+	text-align: left;
+	vertical-align: middle
+}
+
+@media print {
+
+	.moj-filter__heading-action,
+	.moj-filter__heading-title {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+
+	.moj-filter__heading-action,
+	.moj-filter__heading-title {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+
+	.moj-filter__heading-action,
+	.moj-filter__heading-title {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-filter-tags {
+	font-size: 0;
+	margin-bottom: 20px;
+	padding-left: 0
+}
+
+.moj-filter-tags li {
+	display: inline-block;
+	margin-right: 10px
+}
+
+.moj-filter__tag {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	background-color: #fff;
+	border: 1px solid #0b0c0c;
+	color: #0b0c0c;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	line-height: 1.1428571429;
+	margin-top: 5px;
+	padding: 5px;
+	text-decoration: none
+}
+
+@media print {
+	.moj-filter__tag {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-filter__tag {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-filter__tag {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-filter__tag:link,
+.moj-filter__tag:visited {
+	color: #0b0c0c
+}
+
+.moj-filter__tag:focus {
+	background-color: #fd0;
+	color: #0b0c0c
+}
+
+.moj-filter__tag:hover {
+	background-color: #0b0c0c;
+	color: #fff
+}
+
+.moj-filter__tag:after {
+	background-image: url(/assets/images/icon-tag-remove-cross.svg);
+	content: "";
+	display: inline-block;
+	font-weight: 700;
+	height: 10px;
+	margin-left: 5px;
+	vertical-align: middle;
+	width: 10px
+}
+
+.moj-filter__tag:hover:after {
+	background-image: url(/assets/images/icon-tag-remove-cross-white.svg)
+}
+
+.moj-filter__options {
+	box-shadow: inset 0 0 0 1px #b1b4b6;
+	margin-top: -1px;
+	padding: 20px
+}
+
+.moj-filter__options div:last-of-type {
+	margin-bottom: 0
+}
+
+.moj-header {
+	background-color: #0b0c0c;
+	border-bottom: 10px solid #1d70b8;
+	padding-top: 15px
+}
+
+.moj-header__container {
+	margin: 0 15px;
+	max-width: 960px;
+	position: relative
+}
+
+@media (min-width:40.0625em) {
+	.moj-header__container {
+		margin: 0 30px
+	}
+}
+
+@media (min-width:1020px) {
+	.moj-header__container {
+		margin: 0 auto
+	}
+}
+
+.moj-header__container:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-header__logo {
+	padding-bottom: 5px
+}
+
+@media (min-width:48.0625em) {
+	.moj-header__logo {
+		float: left
+	}
+}
+
+.moj-header__logotype-crown {
+	margin-right: 5px;
+	position: relative;
+	top: -4px;
+	vertical-align: top
+}
+
+.moj-header__logotype-crest {
+	margin-right: 5px;
+	position: relative;
+	top: -6px;
+	vertical-align: top
+}
+
+.moj-header__content {
+	padding-bottom: 10px
+}
+
+@media (min-width:48.0625em) {
+	.moj-header__content {
+		float: right
+	}
+}
+
+.moj-header__link,
+.moj-header__link>a {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	border-bottom: 1px solid transparent;
+	color: #fff;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	line-height: 25px;
+	margin-bottom: -1px;
+	overflow: hidden;
+	text-decoration: underline;
+	text-decoration: none;
+	vertical-align: middle
+}
+
+@media print {
+
+	.moj-header__link,
+	.moj-header__link>a {
+		font-family: sans-serif
+	}
+}
+
+.moj-header__link:focus,
+.moj-header__link>a:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-header__link:link,
+.moj-header__link>a:link {
+	color: #1d70b8
+}
+
+.moj-header__link:visited,
+.moj-header__link>a:visited {
+	color: #4c2c92
+}
+
+.moj-header__link:hover,
+.moj-header__link>a:hover {
+	color: #003078
+}
+
+.moj-header__link:active,
+.moj-header__link>a:active {
+	color: #0b0c0c
+}
+
+.moj-header__link:active,
+.moj-header__link:hover,
+.moj-header__link:link,
+.moj-header__link:visited,
+.moj-header__link>a:active,
+.moj-header__link>a:hover,
+.moj-header__link>a:link,
+.moj-header__link>a:visited {
+	color: #fff
+}
+
+.moj-header__link:hover,
+.moj-header__link>a:hover {
+	border-color: #fff
+}
+
+.moj-header__link:focus,
+.moj-header__link>a:focus {
+	border-color: transparent;
+	color: #0b0c0c
+}
+
+.moj-header__link--organisation-name,
+.moj-header__link>a--organisation-name {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 18px;
+	font-size: 1.125rem;
+	font-weight: 700;
+	line-height: 1.1111111111;
+	vertical-align: middle
+}
+
+@media print {
+
+	.moj-header__link--organisation-name,
+	.moj-header__link>a--organisation-name {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+
+	.moj-header__link--organisation-name,
+	.moj-header__link>a--organisation-name {
+		font-size: 24px;
+		font-size: 1.5rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+
+	.moj-header__link--organisation-name,
+	.moj-header__link>a--organisation-name {
+		font-size: 18pt;
+		line-height: 1.15
+	}
+}
+
+.moj-header__link--organisation-name:hover,
+.moj-header__link>a--organisation-name:hover {
+	border-color: transparent
+}
+
+.moj-header__link--service-name,
+.moj-header__link>a--service-name {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 18px;
+	font-size: 1.125rem;
+	line-height: 1.1111111111;
+	vertical-align: middle
+}
+
+@media print {
+
+	.moj-header__link--service-name,
+	.moj-header__link>a--service-name {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+
+	.moj-header__link--service-name,
+	.moj-header__link>a--service-name {
+		font-size: 24px;
+		font-size: 1.5rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+
+	.moj-header__link--service-name,
+	.moj-header__link>a--service-name {
+		font-size: 18pt;
+		line-height: 1.15
+	}
+}
+
+@media (max-width:48.0525em) {
+
+	.moj-header__link--service-name,
+	.moj-header__link>a--service-name {
+		display: block
+	}
+}
+
+@media (min-width:48.0625em) {
+
+	.moj-header__link--service-name,
+	.moj-header__link>a--service-name {
+		margin-left: 5px
+	}
+}
+
+.moj-header__link--service-name:hover,
+.moj-header__link>a--service-name:hover {
+	border-color: transparent
+}
+
+.moj-header__link a {
+	margin-bottom: 1px;
+	vertical-align: text-bottom
+}
+
+.moj-header__link a:hover {
+	border-color: #fff
+}
+
+@media (max-width:48.0525em) {
+	.moj-header__link a {
+		margin-bottom: -1px;
+		vertical-align: middle
+	}
+}
+
+span.moj-header__link:hover {
+	border-color: transparent
+}
+
+.moj-header__navigation {
+	color: #fff;
+	margin-top: 3px
+}
+
+.moj-header__navigation-list {
+	font-size: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+
+.moj-header__navigation-item {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-right: 20px
+}
+
+@media print {
+	.moj-header__navigation-item {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-header__navigation-item {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-header__navigation-item {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-header__navigation-item:last-child {
+	margin-right: 0
+}
+
+.moj-header__navigation-link {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	text-decoration: underline
+}
+
+@media print {
+	.moj-header__navigation-link {
+		font-family: sans-serif
+	}
+}
+
+.moj-header__navigation-link:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-header__navigation-link:link {
+	color: #1d70b8
+}
+
+.moj-header__navigation-link:visited {
+	color: #4c2c92
+}
+
+.moj-header__navigation-link:hover {
+	color: #003078
+}
+
+.moj-header__navigation-link:active {
+	color: #0b0c0c
+}
+
+.moj-header__navigation-link:active,
+.moj-header__navigation-link:link,
+.moj-header__navigation-link:visited {
+	color: inherit;
+	text-decoration: none
+}
+
+.moj-header__navigation-link:hover {
+	text-decoration: underline !important
+}
+
+.moj-header__navigation-link:focus {
+	color: #0b0c0c
+}
+
+.moj-header__navigation-link[aria-current=page] {
+	text-decoration: none
+}
+
+.moj-identity-bar {
+	background-color: #fff;
+	box-shadow: inset 0 -1px 0 0 #b1b4b6;
+	color: #0b0c0c;
+	padding-bottom: 9px;
+	padding-top: 10px
+}
+
+.moj-identity-bar:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-identity-bar__container {
+	font-size: 0;
+	margin: 0 15px;
+	max-width: 960px;
+	text-align: justify
+}
+
+@media (min-width:40.0625em) {
+	.moj-identity-bar__container {
+		margin: 0 30px
+	}
+}
+
+@media (min-width:1020px) {
+	.moj-identity-bar__container {
+		margin: 0 auto
+	}
+}
+
+.moj-identity-bar__container:after {
+	content: "";
+	display: inline-block;
+	width: 100%
+}
+
+.moj-identity-bar__title {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	line-height: 1.1428571429;
+	vertical-align: top
+}
+
+@media print {
+	.moj-identity-bar__title {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-identity-bar__title {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-identity-bar__title {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-identity-bar__details {
+	margin-right: 10px;
+	padding-bottom: 5px;
+	padding-top: 5px
+}
+
+@media (min-width:40.0625em) {
+	.moj-identity-bar__details {
+		display: inline-block;
+		padding-bottom: 9px;
+		padding-top: 11px;
+		vertical-align: top
+	}
+}
+
+.moj-identity-bar__actions {
+	margin-bottom: -10px
+}
+
+@media (min-width:40.0625em) {
+	.moj-identity-bar__actions {
+		display: inline-block;
+		vertical-align: middle
+	}
+}
+
+.moj-identity-bar__menu {
+	display: inline-block;
+	margin-right: 10px
+}
+
+.moj-identity-bar__menu:last-child {
+	margin-right: 0
+}
+
+.moj-messages-container {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	border: 1px solid #b1b4b6;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-messages-container {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-messages-container {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-messages-container {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-message-list {
+	min-height: 200px;
+	overflow-x: hidden;
+	overflow-y: scroll;
+	padding: 5px
+}
+
+.moj-message-list__date {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #505a5f;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25;
+	padding: 15px 0;
+	text-align: center;
+	width: 100%
+}
+
+@media print {
+	.moj-message-list__date {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-message-list__date {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-message-list__date {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-message-item {
+	border-radius: .5em .5em .75em .5em;
+	margin-bottom: 5px;
+	padding: 15px;
+	position: relative
+}
+
+@media (min-width:40.0625em) {
+	.moj-message-item {
+		width: 50%
+	}
+}
+
+.moj-message-item--sent {
+	background-color: #1d70b8;
+	color: #fff;
+	float: right;
+	margin-right: 10px;
+	padding-right: 25px;
+	text-align: right
+}
+
+.moj-message-item--sent:after {
+	border-bottom-left-radius: 1.75em 1.5em;
+	border-left: 1em solid #1d70b8;
+	bottom: 0;
+	content: "";
+	height: 1.5em;
+	position: absolute;
+	right: -1.5em;
+	width: 1.5em
+}
+
+.moj-message-item--received {
+	background-color: #f3f2f1;
+	float: left;
+	margin-left: 10px;
+	padding-left: 25px
+}
+
+.moj-message-item--received:after {
+	border-bottom-right-radius: 1.75em 1.5em;
+	border-right: 1em solid #f3f2f1;
+	bottom: 0;
+	content: "";
+	height: 1.5em;
+	left: -1.5em;
+	position: absolute;
+	width: 1.5em
+}
+
+.moj-message-item a:link,
+.moj-message-item a:visited {
+	color: #fff
+}
+
+.moj-message-item a:focus {
+	color: #0b0c0c
+}
+
+.moj-message-item__text--sent table {
+	color: #fff
+}
+
+.moj-message-item__text--sent table td,
+.moj-message-item__text--sent table th {
+	border-bottom: 1px solid #fff
+}
+
+.moj-message-item__meta {
+	margin-top: 10px
+}
+
+.moj-message-item__meta--sender {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 700;
+	line-height: 1.1428571429
+}
+
+@media print {
+	.moj-message-item__meta--sender {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-message-item__meta--sender {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-message-item__meta--sender {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-message-item__meta--timestamp {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 700;
+	line-height: 1.1428571429
+}
+
+@media print {
+	.moj-message-item__meta--timestamp {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-message-item__meta--timestamp {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-message-item__meta--timestamp {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-multi-file-upload {
+	margin-bottom: 40px
+}
+
+.moj-multi-file-upload--enhanced .moj-multi-file-upload__button {
+	display: none
+}
+
+.moj-multi-file-upload__dropzone {
+	display: flex;
+	outline: 3px dashed #0b0c0c;
+	padding: 60px 15px;
+	text-align: center;
+	transition: outline-offset .1s ease-in-out, background-color .1s linear
+}
+
+.moj-multi-file-upload__dropzone label {
+	display: inline-block;
+	margin-bottom: 0;
+	width: auto
+}
+
+.moj-multi-file-upload__dropzone p {
+	margin-bottom: 0;
+	margin-right: 10px;
+	padding-top: 7px
+}
+
+.moj-multi-file-upload__dropzone [type=file] {
+	left: -9999em;
+	position: absolute
+}
+
+.moj-multi-file-upload--dragover {
+	background: #b1b4b6;
+	outline-color: #6f777b
+}
+
+.moj-multi-file-upload--focused {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none
+}
+
+.moj-multi-file-upload__error {
+	color: #d4351c;
+	font-weight: 700
+}
+
+.moj-multi-file-upload__success {
+	color: #00703c;
+	font-weight: 700
+}
+
+.moj-multi-file-upload__error svg,
+.moj-multi-file-upload__success svg {
+	fill: currentColor;
+	float: left;
+	margin-right: 10px
+}
+
+.moj-multi-select__checkbox {
+	display: inline-block;
+	padding-left: 0
+}
+
+.moj-multi-select__toggle-label {
+	margin: 0 !important;
+	padding: 0 !important
+}
+
+.moj-notification-badge {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	background-color: #d4351c;
+	border-radius: 75px;
+	color: #fff;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-size: 16px;
+	font-weight: 700;
+	font-weight: 600;
+	line-height: 1.1428571429;
+	min-width: 15px;
+	padding: 5px 8px 2px;
+	text-align: center;
+	white-space: nowrap
+}
+
+@media print {
+	.moj-notification-badge {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-notification-badge {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-notification-badge {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-organisation-nav {
+	border-bottom: 1px solid #b1b4b6;
+	margin-bottom: 15px;
+	margin-top: 10px;
+	padding-bottom: 5px
+}
+
+.moj-organisation-nav:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-organisation-nav__title {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-organisation-nav__title {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-organisation-nav__title {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-organisation-nav__title {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-organisation-nav__title {
+		float: left;
+		width: 75%
+	}
+}
+
+.moj-organisation-nav__link {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	text-decoration: underline
+}
+
+@media print {
+	.moj-organisation-nav__link {
+		font-family: sans-serif
+	}
+}
+
+.moj-organisation-nav__link:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-organisation-nav__link:link {
+	color: #1d70b8
+}
+
+.moj-organisation-nav__link:visited {
+	color: #4c2c92
+}
+
+.moj-organisation-nav__link:hover {
+	color: #003078
+}
+
+.moj-organisation-nav__link:active,
+.moj-organisation-nav__link:focus {
+	color: #0b0c0c
+}
+
+@media print {
+
+	.moj-organisation-nav__link[href^="/"]:after,
+	.moj-organisation-nav__link[href^="http://"]:after,
+	.moj-organisation-nav__link[href^="https://"]:after {
+		word-wrap: break-word;
+		content: " (" attr(href) ")";
+		font-size: 90%
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-organisation-nav__link {
+		float: right
+	}
+}
+
+.moj-page-header-actions {
+	font-size: 0;
+	margin-bottom: 40px;
+	min-height: 40px;
+	text-align: justify
+}
+
+.moj-page-header-actions:after {
+	clear: both;
+	content: "";
+	display: block;
+	display: inline-block;
+	width: 100%
+}
+
+.moj-page-header-actions__title [class^=govuk-heading-] {
+	margin-bottom: 10px;
+	text-align: left
+}
+
+@media (min-width:40.0625em) {
+	.moj-page-header-actions__title [class^=govuk-heading-] {
+		margin-bottom: 0
+	}
+
+	.moj-page-header-actions__actions,
+	.moj-page-header-actions__title {
+		display: inline-block;
+		vertical-align: middle
+	}
+}
+
+.moj-page-header-actions__action:last-child {
+	margin-bottom: 0
+}
+
+@media (min-width:40.0625em) {
+	.moj-page-header-actions__action {
+		margin-bottom: 0
+	}
+}
+
+@media (min-width:48.0625em) {
+	.moj-pagination {
+		font-size: 0;
+		margin-left: -5px;
+		margin-right: -5px;
+		text-align: justify
+	}
+
+	.moj-pagination:after {
+		content: "";
+		display: inline-block;
+		width: 100%
+	}
+}
+
+.moj-pagination__list {
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+
+@media (min-width:48.0625em) {
+	.moj-pagination__list {
+		display: inline-block;
+		margin-bottom: 0;
+		vertical-align: middle
+	}
+}
+
+.moj-pagination__results {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-top: 0
+}
+
+@media print {
+	.moj-pagination__results {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-pagination__results {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-pagination__results {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+@media (min-width:48.0625em) {
+	.moj-pagination__results {
+		display: inline-block;
+		margin-bottom: 0;
+		vertical-align: middle
+	}
+}
+
+.moj-pagination__item {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-pagination__item {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-pagination__item {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-pagination__item {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-pagination__item--active,
+.moj-pagination__item--dots {
+	font-weight: 700;
+	height: 25px;
+	padding: 5px 10px;
+	text-align: center
+}
+
+.moj-pagination__item--dots {
+	padding-left: 0;
+	padding-right: 0
+}
+
+.moj-pagination__item--next .moj-pagination__link:after,
+.moj-pagination__item--prev .moj-pagination__link:before {
+	background: transparent;
+	border-style: solid;
+	color: #0b0c0c;
+	content: "";
+	display: inline-block;
+	height: 10px;
+	transform: rotate(-45deg);
+	width: 10px
+}
+
+.moj-pagination__item--prev .moj-pagination__link:before {
+	border-width: 3px 0 0 3px;
+	margin-right: 5px
+}
+
+.moj-pagination__item--next .moj-pagination__link:after {
+	border-width: 0 3px 3px 0;
+	margin-left: 5px
+}
+
+.moj-pagination__link {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	min-width: 25px;
+	padding: 5px;
+	text-align: center;
+	text-decoration: underline;
+	text-decoration: none
+}
+
+@media print {
+	.moj-pagination__link {
+		font-family: sans-serif
+	}
+}
+
+.moj-pagination__link:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-pagination__link:link {
+	color: #1d70b8
+}
+
+.moj-pagination__link:visited {
+	color: #4c2c92
+}
+
+.moj-pagination__link:hover {
+	color: #003078
+}
+
+.moj-pagination__link:active {
+	color: #0b0c0c
+}
+
+.moj-pagination__link:link,
+.moj-pagination__link:visited {
+	color: #1d70b8
+}
+
+.moj-pagination__link:hover {
+	color: #5694ca
+}
+
+.moj-pagination__link:focus {
+	color: #0b0c0c
+}
+
+.moj-pagination__results {
+	padding: 5px
+}
+
+.moj-password-reveal {
+	display: flex
+}
+
+.moj-password-reveal__input {
+	margin-right: 5px
+}
+
+.moj-password-reveal__button {
+	width: 80px
+}
+
+.moj-primary-navigation {
+	background-color: #f3f2f1
+}
+
+.moj-primary-navigation__container {
+	font-size: 0;
+	margin: 0 15px;
+	max-width: 960px;
+	text-align: justify
+}
+
+@media (min-width:40.0625em) {
+	.moj-primary-navigation__container {
+		margin: 0 30px
+	}
+}
+
+@media (min-width:1020px) {
+	.moj-primary-navigation__container {
+		margin: 0 auto
+	}
+}
+
+.moj-primary-navigation__container:after {
+	content: "";
+	display: inline-block;
+	width: 100%
+}
+
+.moj-primary-navigation__nav {
+	text-align: left
+}
+
+@media (min-width:48.0625em) {
+	.moj-primary-navigation__nav {
+		display: inline-block;
+		vertical-align: middle
+	}
+}
+
+.moj-primary-navigation__list {
+	font-size: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+
+.moj-primary-navigation__item {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-right: 20px;
+	margin-top: 0
+}
+
+@media print {
+	.moj-primary-navigation__item {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-primary-navigation__item {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-primary-navigation__item {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-primary-navigation__item:last-child {
+	margin-right: 0
+}
+
+.moj-primary-navigation__link {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-weight: 700;
+	padding-bottom: 15px;
+	padding-top: 15px;
+	text-decoration: underline;
+	text-decoration: none
+}
+
+@media print {
+	.moj-primary-navigation__link {
+		font-family: sans-serif
+	}
+}
+
+.moj-primary-navigation__link:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-primary-navigation__link:link {
+	color: #1d70b8
+}
+
+.moj-primary-navigation__link:visited {
+	color: #4c2c92
+}
+
+.moj-primary-navigation__link:hover {
+	color: #003078
+}
+
+.moj-primary-navigation__link:active {
+	color: #0b0c0c
+}
+
+.moj-primary-navigation__link:link,
+.moj-primary-navigation__link:visited {
+	color: #1d70b8
+}
+
+.moj-primary-navigation__link:hover {
+	color: #5694ca
+}
+
+.moj-primary-navigation__link:focus {
+	box-shadow: none;
+	color: #0b0c0c;
+	position: relative;
+	z-index: 1
+}
+
+.moj-primary-navigation__link:focus:before {
+	background-color: #0b0c0c;
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 5px;
+	left: 0;
+	position: absolute;
+	width: 100%
+}
+
+.moj-primary-navigation__link[aria-current] {
+	color: #1d70b8;
+	font-weight: 700;
+	position: relative;
+	text-decoration: none
+}
+
+.moj-primary-navigation__link[aria-current]:before {
+	background-color: #1d70b8;
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 5px;
+	left: 0;
+	position: absolute;
+	width: 100%
+}
+
+.moj-primary-navigation__link[aria-current]:focus {
+	border: none;
+	color: #0b0c0c;
+	position: relative
+}
+
+.moj-primary-navigation__link[aria-current]:focus:before {
+	background-color: #0b0c0c
+}
+
+@media (min-width:48.0625em) {
+	.moj-primary-navigation__search {
+		display: inline-block;
+		vertical-align: middle
+	}
+}
+
+.moj-progress-bar {
+	margin-bottom: 40px
+}
+
+.moj-progress-bar__list {
+	font-size: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0;
+	position: relative;
+	text-align: justify;
+	vertical-align: top
+}
+
+.moj-progress-bar__list:after {
+	content: "";
+	display: inline-block;
+	width: 100%
+}
+
+.moj-progress-bar__list:before {
+	border-top: 6px solid #00703c;
+	content: "";
+	left: 0;
+	position: absolute;
+	top: 13px;
+	width: 100%
+}
+
+.moj-progress-bar__item {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	max-width: 20%;
+	position: relative;
+	text-align: center;
+	vertical-align: top
+}
+
+@media print {
+	.moj-progress-bar__item {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-progress-bar__item {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-progress-bar__item {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-progress-bar__item:first-child:before,
+.moj-progress-bar__item:last-child:before {
+	border-top: 6px solid #fff;
+	content: "";
+	left: 0;
+	position: absolute;
+	top: 13px;
+	width: 50%
+}
+
+.moj-progress-bar__item:first-child:before {
+	left: 0
+}
+
+.moj-progress-bar__item:last-child:before {
+	left: auto;
+	right: 0
+}
+
+.moj-progress-bar__item[aria-current=step] {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-progress-bar__item[aria-current=step] {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-progress-bar__item[aria-current=step] {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-progress-bar__item[aria-current=step] {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-progress-bar__icon {
+	background-color: #fff;
+	border: 6px solid #00703c;
+	border-radius: 50%;
+	box-sizing: border-box;
+	display: block;
+	height: 32px;
+	margin-left: auto;
+	margin-right: auto;
+	position: relative;
+	width: 32px
+}
+
+.moj-progress-bar__icon--complete {
+	background-color: #00703c;
+	background-image: url(/assets/images/icon-progress-tick.svg);
+	background-position: 50% 50%;
+	background-repeat: no-repeat
+}
+
+.moj-progress-bar__label {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	word-wrap: break-word;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	font-weight: inherit;
+	line-height: 1.1428571429;
+	margin-top: 15px;
+	position: relative
+}
+
+@media print {
+	.moj-progress-bar__label {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-progress-bar__label {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-progress-bar__label {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-rich-text-editor__toolbar {
+	margin-bottom: 10px
+}
+
+.moj-rich-text-editor__toolbar:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-rich-text-editor__toolbar-button {
+	background-color: #fff;
+	background-position: 50% 50%;
+	background-repeat: no-repeat;
+	background-size: 40px 40px;
+	border: 2px solid #0b0c0c;
+	color: #0b0c0c;
+	cursor: pointer;
+	float: left;
+	height: 40px;
+	margin-left: -2px;
+	outline: 0;
+	text-decoration: none;
+	vertical-align: top;
+	width: 40px
+}
+
+.moj-rich-text-editor__toolbar-button:first-child {
+	margin-left: 0
+}
+
+.moj-rich-text-editor__toolbar-button::-moz-focus-inner {
+	border: 0;
+	padding: 0
+}
+
+.moj-rich-text-editor__toolbar-button:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none;
+	position: relative;
+	z-index: 2
+}
+
+.moj-rich-text-editor__toolbar-button--bold {
+	background-image: url(/assets/images/icon-wysiwyg-bold.svg)
+}
+
+.moj-rich-text-editor__toolbar-button--italic {
+	background-image: url(/assets/images/icon-wysiwyg-italic.svg)
+}
+
+.moj-rich-text-editor__toolbar-button--underline {
+	background-image: url(/assets/images/icon-wysiwyg-underline.svg)
+}
+
+.moj-rich-text-editor__toolbar-button--unordered-list {
+	background-image: url(/assets/images/icon-wysiwyg-unordered-list.svg);
+	margin-left: 10px
+}
+
+.moj-rich-text-editor__toolbar-button--ordered-list {
+	background-image: url(/assets/images/icon-wysiwyg-ordered-list.svg)
+}
+
+.moj-rich-text-editor__content {
+	min-height: 130px;
+	outline: none;
+	overflow: auto;
+	resize: vertical
+}
+
+.moj-search-toggle__button {
+	-moz-osx-font-smoothing: grayscale;
+	-webkit-font-smoothing: antialiased;
+	-webkit-appearance: none;
+	background-color: transparent;
+	border: none;
+	color: #1d70b8;
+	cursor: pointer;
+	display: inline-block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25;
+	padding: 12px 0 13px
+}
+
+@media print {
+	.moj-search-toggle__button {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-search-toggle__button {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-search-toggle__button {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-search-toggle__button__icon {
+	fill: currentColor;
+	display: inline-block;
+	height: 20px;
+	margin-left: 10px;
+	vertical-align: middle;
+	width: 20px
+}
+
+@media screen and (forced-colors:active) {
+	.moj-search-toggle__button__icon {
+		fill: windowText
+	}
+}
+
+.moj-search-toggle__button:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none;
+	position: relative;
+	z-index: 1
+}
+
+.moj-search--toggle {
+	padding: 15px
+}
+
+@media (max-width:48.0525em) {
+	.moj-search--toggle {
+		padding-left: 0 !important;
+		padding-right: 0 !important
+	}
+
+	.js-enabled .moj-search--toggle {
+		padding-top: 0 !important
+	}
+}
+
+.js-enabled .moj-search-toggle {
+	position: relative
+}
+
+.js-enabled .moj-search-toggle__search {
+	background-color: #f3f2f1
+}
+
+@media (min-width:48.0625em) {
+	.js-enabled .moj-search-toggle__search {
+		max-width: 450px;
+		position: absolute;
+		right: -15px;
+		top: 50px;
+		width: 450px;
+		z-index: 10
+	}
+}
+
+.moj-search {
+	font-size: 0
+}
+
+.moj-search form {
+	align-items: flex-end;
+	display: flex
+}
+
+.moj-search .govuk-form-group {
+	display: inline-block;
+	flex: 1;
+	margin-bottom: 0;
+	vertical-align: top
+}
+
+.moj-search__hint,
+.moj-search__label {
+	text-align: left
+}
+
+.moj-search__input:focus {
+	position: relative;
+	z-index: 1
+}
+
+.moj-search__button {
+	display: inline-block;
+	margin-bottom: 0;
+	margin-left: 10px;
+	position: relative;
+	top: -2px;
+	vertical-align: bottom;
+	width: auto
+}
+
+.moj-search--inline {
+	padding: 10px 0 !important
+}
+
+@media (min-width:48.0625em) {
+	.moj-search--inline {
+		padding: 0 !important
+	}
+}
+
+.moj-side-navigation {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	line-height: 1.1428571429
+}
+
+@media print {
+	.moj-side-navigation {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-side-navigation {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-side-navigation {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+@media (max-width:40.0525em) {
+	.moj-side-navigation {
+		display: flex;
+		overflow-x: scroll
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-side-navigation {
+		display: block;
+		padding: 20px 0 0
+	}
+}
+
+.moj-side-navigation__title {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #505a5f;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin: 0;
+	padding: 10px 10px 10px 14px
+}
+
+@media print {
+	.moj-side-navigation__title {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-side-navigation__title {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-side-navigation__title {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+@media (max-width:40.0525em) {
+	.moj-side-navigation__title {
+		display: none
+	}
+}
+
+.moj-side-navigation__list {
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+
+@media (max-width:40.0525em) {
+	.moj-side-navigation__list {
+		display: flex;
+		margin: 0;
+		white-space: nowrap
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-side-navigation__list {
+		margin-bottom: 20px
+	}
+}
+
+@media (max-width:40.0525em) {
+	.moj-side-navigation__item {
+		display: flex
+	}
+}
+
+.moj-side-navigation__item a,
+.moj-side-navigation__item a:link,
+.moj-side-navigation__item a:visited {
+	background-color: inherit;
+	color: #1d70b8;
+	display: block;
+	text-decoration: none
+}
+
+@media (max-width:40.0525em) {
+
+	.moj-side-navigation__item a,
+	.moj-side-navigation__item a:link,
+	.moj-side-navigation__item a:visited {
+		border-bottom: 4px solid transparent;
+		padding: 15px 15px 11px
+	}
+}
+
+@media (min-width:40.0625em) {
+
+	.moj-side-navigation__item a,
+	.moj-side-navigation__item a:link,
+	.moj-side-navigation__item a:visited {
+		background-color: inherit;
+		border-left: 4px solid transparent;
+		padding: 10px
+	}
+}
+
+.moj-side-navigation__item a:hover {
+	border-color: #5694ca
+}
+
+.moj-side-navigation__item a:focus {
+	background-color: #fd0;
+	border-color: #0b0c0c #0b0c0c #0b0c0c transparent;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	position: relative
+}
+
+.moj-side-navigation__item--active a:link,
+.moj-side-navigation__item--active a:visited {
+	border-color: #1d70b8;
+	color: #1d70b8;
+	font-weight: 700
+}
+
+.moj-side-navigation__item--active a:focus {
+	background-color: #fd0;
+	border-color: #0b0c0c #0b0c0c #0b0c0c transparent;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c
+}
+
+@media (min-width:40.0625em) {
+
+	.moj-side-navigation__item--active a:link,
+	.moj-side-navigation__item--active a:visited {
+		background-color: #f3f2f1
+	}
+
+	.moj-side-navigation__item--active a:focus {
+		background-color: #fd0;
+		border-color: transparent;
+		color: #0b0c0c
+	}
+}
+
+[aria-sort] button,
+[aria-sort] button:hover {
+	background-color: transparent;
+	border-width: 0;
+	box-shadow: 0 0 0 0;
+	color: #005ea5;
+	cursor: pointer;
+	font-family: inherit;
+	font-size: inherit;
+	font-size: 1em;
+	font-weight: inherit;
+	margin: 0;
+	padding: 0 10px 0 0;
+	position: relative;
+	text-align: inherit
+}
+
+[aria-sort] button:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	color: #0b0c0c;
+	outline: none
+}
+
+[aria-sort]:first-child button {
+	right: auto
+}
+
+[aria-sort] button:before {
+	content: " ▼";
+	font-size: .5em;
+	position: absolute;
+	right: -1px;
+	top: 9px
+}
+
+[aria-sort] button:after {
+	content: " ▲";
+	font-size: .5em;
+	position: absolute;
+	right: -1px;
+	top: 1px
+}
+
+[aria-sort=ascending] button:before,
+[aria-sort=descending] button:before {
+	content: none
+}
+
+[aria-sort=ascending] button:after {
+	content: " ▲";
+	font-size: .8em;
+	position: absolute;
+	right: -5px;
+	top: 2px
+}
+
+[aria-sort=descending] button:after {
+	content: " ▼";
+	font-size: .8em;
+	position: absolute;
+	right: -5px;
+	top: 2px
+}
+
+.moj-sub-navigation {
+	margin-bottom: 40px
+}
+
+.moj-sub-navigation__list {
+	font-size: 0;
+	list-style: none;
+	margin: 0;
+	padding: 0
+}
+
+@media (min-width:40.0625em) {
+	.moj-sub-navigation__list {
+		box-shadow: inset 0 -1px 0 #b1b4b6;
+		width: 100%
+	}
+}
+
+.moj-sub-navigation__item {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	box-shadow: inset 0 -1px 0 #b1b4b6;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-top: -1px
+}
+
+@media print {
+	.moj-sub-navigation__item {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-sub-navigation__item {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-sub-navigation__item {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-sub-navigation__item:last-child {
+	box-shadow: none
+}
+
+@media (min-width:40.0625em) {
+	.moj-sub-navigation__item {
+		box-shadow: none;
+		display: inline-block;
+		margin-right: 20px;
+		margin-top: 0
+	}
+}
+
+.moj-sub-navigation__link {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: block;
+	font-family: GDS Transport, arial, sans-serif;
+	padding-bottom: 12px;
+	padding-left: 15px;
+	padding-top: 12px;
+	position: relative;
+	text-decoration: underline;
+	text-decoration: none
+}
+
+@media print {
+	.moj-sub-navigation__link {
+		font-family: sans-serif
+	}
+}
+
+.moj-sub-navigation__link:focus {
+	background-color: #fd0;
+	box-shadow: 0 -2px #fd0, 0 4px #0b0c0c;
+	outline: 3px solid transparent;
+	text-decoration: none
+}
+
+.moj-sub-navigation__link:link {
+	color: #1d70b8
+}
+
+.moj-sub-navigation__link:visited {
+	color: #4c2c92
+}
+
+.moj-sub-navigation__link:hover {
+	color: #003078
+}
+
+.moj-sub-navigation__link:active {
+	color: #0b0c0c
+}
+
+@media (min-width:40.0625em) {
+	.moj-sub-navigation__link {
+		padding-left: 0
+	}
+}
+
+.moj-sub-navigation__link:link,
+.moj-sub-navigation__link:visited {
+	color: #1d70b8
+}
+
+.moj-sub-navigation__link:hover {
+	color: #5694ca
+}
+
+.moj-sub-navigation__link:focus {
+	box-shadow: none;
+	color: #0b0c0c;
+	position: relative
+}
+
+.moj-sub-navigation__link:focus:before {
+	background-color: #0b0c0c;
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 5px;
+	left: 0;
+	position: absolute;
+	right: 0;
+	width: 100%
+}
+
+.moj-sub-navigation__link[aria-current=page] {
+	color: #0b0c0c;
+	position: relative;
+	text-decoration: none
+}
+
+.moj-sub-navigation__link[aria-current=page]:before {
+	background-color: #1d70b8;
+	bottom: 0;
+	content: "";
+	display: block;
+	height: 100%;
+	left: 0;
+	position: absolute;
+	width: 5px
+}
+
+@media (min-width:40.0625em) {
+	.moj-sub-navigation__link[aria-current=page]:before {
+		height: 5px;
+		width: 100%
+	}
+}
+
+.moj-sub-navigation__link[aria-current=page]:focus:before {
+	background-color: #0b0c0c
+}
+
+.moj-tag {
+	background-color: #1d70b8;
+	border: 2px solid #1d70b8;
+	color: #fff
+}
+
+.moj-tag--purple {
+	background-color: #4c2c92;
+	border: 2px solid #4c2c92;
+	color: #fff
+}
+
+.moj-tag--bright-purple {
+	background-color: #912b88;
+	border: 2px solid #912b88;
+	color: #fff
+}
+
+.moj-tag--error,
+.moj-tag--red {
+	background-color: #d4351c;
+	border: 2px solid #d4351c;
+	color: #fff
+}
+
+.moj-tag--green,
+.moj-tag--success {
+	background-color: #00703c;
+	border: 2px solid #00703c;
+	color: #fff
+}
+
+.moj-tag--blue,
+.moj-tag--information {
+	background-color: #1d70b8;
+	border: 2px solid #1d70b8;
+	color: #fff
+}
+
+.moj-tag--black {
+	background-color: #0b0c0c;
+	border: 2px solid #0b0c0c;
+	color: #fff
+}
+
+.moj-tag--grey {
+	background-color: #505a5f;
+	border: 2px solid #505a5f;
+	color: #fff
+}
+
+.moj-task-list {
+	list-style-type: none;
+	margin-bottom: 0;
+	margin-top: 0;
+	padding-left: 0
+}
+
+@media (min-width:40.0625em) {
+	.moj-task-list {
+		min-width: 550px
+	}
+}
+
+.moj-task-list__section {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: table;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 18px;
+	font-size: 1.125rem;
+	font-weight: 700;
+	line-height: 1.1111111111
+}
+
+@media print {
+	.moj-task-list__section {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-task-list__section {
+		font-size: 24px;
+		font-size: 1.5rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-task-list__section {
+		font-size: 18pt;
+		line-height: 1.15
+	}
+}
+
+.moj-task-list__section-number {
+	display: table-cell
+}
+
+@media (min-width:40.0625em) {
+	.moj-task-list__section-number {
+		min-width: 30px;
+		padding-right: 0
+	}
+}
+
+.moj-task-list__items {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	list-style: none;
+	margin-bottom: 40px;
+	padding-left: 0
+}
+
+@media print {
+	.moj-task-list__items {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-task-list__items {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-task-list__items {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-task-list__items {
+		margin-bottom: 60px;
+		padding-left: 30px
+	}
+}
+
+.moj-task-list__item {
+	border-bottom: 1px solid #b1b4b6;
+	margin-bottom: 0 !important;
+	padding-bottom: 10px;
+	padding-top: 10px
+}
+
+.moj-task-list__item:after {
+	clear: both;
+	content: "";
+	display: block
+}
+
+.moj-task-list__item:first-child {
+	border-top: 1px solid #b1b4b6
+}
+
+.moj-task-list__task-name {
+	display: block
+}
+
+@media (min-width:28.125em) {
+	.moj-task-list__task-name {
+		float: left;
+		width: 75%
+	}
+}
+
+.moj-task-list__task-completed {
+	margin-bottom: 5px;
+	margin-top: 10px
+}
+
+@media (min-width:28.125em) {
+	.moj-task-list__task-completed {
+		float: right;
+		margin-bottom: 0;
+		margin-top: 0
+	}
+}
+
+.moj-timeline {
+	margin-bottom: 20px;
+	overflow: hidden;
+	position: relative
+}
+
+.moj-timeline:before {
+	background-color: #1d70b8;
+	content: "";
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 10px;
+	width: 5px
+}
+
+.moj-timeline--full {
+	margin-bottom: 0
+}
+
+.moj-timeline--full:before {
+	height: calc(100% - 75px)
+}
+
+.moj-timeline__item {
+	padding-bottom: 30px;
+	padding-left: 20px;
+	position: relative
+}
+
+.moj-timeline__item:before {
+	background-color: #1d70b8;
+	content: "";
+	height: 5px;
+	left: 0;
+	position: absolute;
+	top: 10px;
+	width: 15px
+}
+
+.moj-timeline__title {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	display: inline;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 700;
+	line-height: 1.25
+}
+
+@media print {
+	.moj-timeline__title {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-timeline__title {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-timeline__title {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-timeline__byline {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	color: #505a5f;
+	display: inline;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin: 0
+}
+
+@media print {
+	.moj-timeline__byline {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-timeline__byline {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-timeline__byline {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-timeline__date {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 14px;
+	font-size: .875rem;
+	font-weight: 400;
+	line-height: 1.1428571429;
+	margin-bottom: 0;
+	margin-top: 5px
+}
+
+@media print {
+	.moj-timeline__date {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-timeline__date {
+		font-size: 16px;
+		font-size: 1rem;
+		line-height: 1.25
+	}
+}
+
+@media print {
+	.moj-timeline__date {
+		font-size: 14pt;
+		line-height: 1.2
+	}
+}
+
+.moj-timeline__description {
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	font-family: GDS Transport, arial, sans-serif;
+	font-size: 16px;
+	font-size: 1rem;
+	font-weight: 400;
+	line-height: 1.25;
+	margin-top: 20px
+}
+
+@media print {
+	.moj-timeline__description {
+		font-family: sans-serif
+	}
+}
+
+@media (min-width:40.0625em) {
+	.moj-timeline__description {
+		font-size: 19px;
+		font-size: 1.1875rem;
+		line-height: 1.3157894737
+	}
+}
+
+@media print {
+	.moj-timeline__description {
+		font-size: 14pt;
+		line-height: 1.15
+	}
+}
+
+.moj-timeline__documents {
+	list-style: none;
+	margin-bottom: 0;
+	padding-left: 0
+}
+
+.moj-timeline__document-item {
+	margin-bottom: 5px
+}
+
+.moj-timeline__document-item:last-child {
+	margin-bottom: 0
+}
+
+.moj-timeline__document-icon {
+	fill: currentColor;
+	float: left;
+	margin-right: 4px;
+	margin-top: 4px
+}
+
+@media screen and (forced-colors:active) {
+	.moj-timeline__document-icon {
+		fill: linkText
+	}
+}
+
+.moj-timeline__document-link {
+	background-image: url(/assets/images/icon-document.svg);
+	background-position: 0 50%;
+	background-repeat: no-repeat;
+	background-size: 20px 16px;
+	padding-left: 25px
+}
+
+.moj-timeline__document-link:focus {
+	color: #0b0c0c
+}
+
+.moj-ticket-panel {
+	display: block;
+	flex-wrap: wrap;
+	margin-right: 0
+}
+
+@media (min-width:48.0625em) {
+	.moj-ticket-panel--inline {
+		display: flex;
+		flex-wrap: nowrap
+	}
+
+	.moj-ticket-panel--inline>*+* {
+		margin-left: 15px
+	}
+}
+
+.moj-ticket-panel__content :last-child {
+	margin-bottom: 0
+}
+
+.moj-ticket-panel__content {
+	background-color: #f3f2f1;
+	border-left: 4px solid transparent;
+	display: block;
+	flex-grow: 1;
+	margin-bottom: 15px;
+	padding: 20px;
+	position: relative
+}
+
+.moj-ticket-panel__content--grey {
+	border-left-color: #b1b4b6
+}
+
+.moj-ticket-panel__content--blue {
+	border-left-color: #1d70b8
+}
+
+.moj-ticket-panel__content--red {
+	border-left-color: #d4351c
+}
+
+.moj-ticket-panel__content--yellow {
+	border-left-color: #fd0
+}
+
+.moj-ticket-panel__content--green {
+	border-left-color: #00703c
+}
+
+.moj-ticket-panel__content--purple {
+	border-left-color: #4c2c92
+}
+
+.moj-ticket-panel__content--orange {
+	border-left-color: #f47738
+}
+
+.js-enabled .moj-js-hidden,
+.moj-hidden {
+	display: none
+}
+
+.moj-width-container {
+	margin: 0 15px;
+	max-width: 960px
+}
+
+@media (min-width:40.0625em) {
+	.moj-width-container {
+		margin: 0 30px
+	}
+}
+
+@media (min-width:1020px) {
+	.moj-width-container {
+		margin: 0 auto
+	}
+}

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -61,6 +61,8 @@ package object controllers {
   val FILTERED_GROUP_SUMMARIES: DataKey[Seq[GroupSummary]] = DataKey("filteredGroupSummaries")
   val FILTERED_GROUPS_INPUT: DataKey[String] = DataKey("filteredGroupsInputValue")
 
+  val CLIENT_REFERENCE: DataKey[String] = DataKey("clientRef")
+
   val sessionKeys =
     List(
       OPTIN_STATUS,
@@ -77,7 +79,8 @@ package object controllers {
       HIDDEN_TEAM_MEMBERS_EXIST,
       SELECTED_TEAM_MEMBERS,
       GROUPS_FOR_UNASSIGNED_CLIENTS,
-      FILTERED_GROUP_SUMMARIES
+      FILTERED_GROUP_SUMMARIES,
+      CLIENT_REFERENCE
     )
 
 }

--- a/app/forms/ClientReferenceForm.scala
+++ b/app/forms/ClientReferenceForm.scala
@@ -1,4 +1,4 @@
-@*
+/*
  * Copyright 2022 HM Revenue & Customs
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +12,24 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *@
+ */
 
-@this()
+package forms
 
-@(key: String = "", id: Option[String] = None, classes: Option[String] = None)(implicit msgs: Messages)
+import play.api.data.Form
+import play.api.data.Forms._
 
-@cls = @{if(classes.isDefined) classes.get.concat(" govuk-caption-l") else "govuk-caption-l"}
+object ClientReferenceForm {
 
-<span class="@cls" @id.map(i=> { s"id =${i}"})>@msgs(key)</span>
+  def form(): Form[String] = {
+    Form(
+      single(
+        "clientRef" ->
+          text
+            .verifying("error.client-reference.required", _.trim.nonEmpty)
+            .verifying("error.client-reference.max-length", _.trim.length < 32)
+      )
+    )
+
+  }
+}

--- a/app/forms/ClientReferenceForm.scala
+++ b/app/forms/ClientReferenceForm.scala
@@ -27,7 +27,7 @@ object ClientReferenceForm {
         "clientRef" ->
           text
             .verifying("error.client-reference.required", _.trim.nonEmpty)
-            .verifying("error.client-reference.max-length", _.trim.length < 32)
+            .verifying("error.client-reference.max-length", _.trim.length < 80)
       )
     )
 

--- a/app/services/ManageClientService.scala
+++ b/app/services/ManageClientService.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import akka.Done
+import connectors.AgentUserClientDetailsConnector
+import controllers.CLIENT_REFERENCE
+import models.DisplayClient
+import models.DisplayClient.toEnrolment
+import play.api.mvc.Request
+import repository.SessionCacheRepository
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Client, EnrolmentKey}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ManageClientService @Inject()(
+    agentUserClientDetailsConnector: AgentUserClientDetailsConnector,
+    sessionCacheRepository: SessionCacheRepository
+) {
+
+  def updateClientReference(arn: Arn, displayClient: DisplayClient, newName: String)(implicit request: Request[_],
+                       hc: HeaderCarrier,
+                       ec: ExecutionContext): Future[Done] = {
+    val client = Client(EnrolmentKey.enrolmentKeys(toEnrolment(displayClient)).head, newName)
+    agentUserClientDetailsConnector.updateClientReference(arn, client)
+  }
+
+  def getNewNameFromSession()(implicit request: Request[_],
+  hc: HeaderCarrier,
+  ec: ExecutionContext): Future[Option[String]] = {
+    for {
+      newName <- sessionCacheRepository.getFromSession(CLIENT_REFERENCE)
+    } yield newName
+  }
+
+}

--- a/app/views/components/link_as_button.scala.html
+++ b/app/views/components/link_as_button.scala.html
@@ -18,7 +18,7 @@
 
 @(
    href: String,
-   key: String = "continue.button",
+   key: String = "common.continue",
    id: String = "button-link",
    submitClass: Option[String] = None
 )(implicit msgs: Messages)

--- a/app/views/components/submit_button.scala.html
+++ b/app/views/components/submit_button.scala.html
@@ -20,7 +20,7 @@
 @this(button: GovukButton)
 
 @(
-    messageKey: String = "continue.button",
+    messageKey: String = "common.continue",
     id: String = "continue",
     name: String = "continue",
     value: String = "continue",

--- a/app/views/group_member_details/client_details.scala.html
+++ b/app/views/group_member_details/client_details.scala.html
@@ -21,6 +21,8 @@
 @import models.AddClientsToGroup
 @import connectors.GroupSummary
 @import views.html.partials.filter_clients_table_form
+@import java.util.Base64
+@import play.api.libs.json.Json
 
 @this(
         layout: main_layout,
@@ -35,9 +37,9 @@
 
 @clientReference = @{
     if(client.name.isEmpty) {
-        Html(msgs("details.clients.no-data")+ "  " + a("common.update", href = "#"))
+        Html(msgs("details.clients.no-data")+ "    " + a("common.update", href = routes.ManageClientController.showUpdateClientReference(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url))
     } else {
-        Html(client.name + "  " + a("common.update", href = "#"))
+        Html(client.name + "    " + a("common.update", href = routes.ManageClientController.showUpdateClientReference(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url))
     }
 }
 

--- a/app/views/group_member_details/update_client_reference.scala.html
+++ b/app/views/group_member_details/update_client_reference.scala.html
@@ -1,0 +1,75 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import controllers.routes
+@import views.html.main_layout
+@import utils.ViewUtils._
+@import models.AddClientsToGroup
+@import java.util.Base64
+@import play.api.libs.json.Json
+
+@this(
+        layout: main_layout,
+        h1: h1, caption: caption,
+        p:p, a: a, span: span,
+        insetText: inset_text,
+        formWithCSRF: FormWithCSRF,
+        textbox: textbox,
+        link_as_button: link_as_button,
+        submit: submit_button
+)
+
+@(
+    client: DisplayClient,
+    form: Form[String],
+)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+
+@displayTaxReference = @{
+    Html(displayObfuscatedReference(client.name, client.hmrcRef))
+}
+
+@layout(
+    title = msgs("update-client-reference"),
+    backLinkHref = Some(routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url),
+    formErrors = form.errors
+) {
+
+    @caption(msgs("update-client-reference.caption", displayTaxReference))
+    @h1("update-client-reference")
+
+    @formWithCSRF(action = routes.ManageClientController.submitUpdateClientReference(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes))) {
+
+    @textbox(
+        field = form("clientRef"),
+        label = "update-client-reference.label",
+        labelClasses = "govuk-label--s",
+        classes = "govuk-input--width-20"
+    )
+
+    @insetText(key = "update-client-reference.text")
+
+
+    <div class="govuk-button-group">
+        @link_as_button(
+            href= routes.ManageClientController.showClientDetails(Base64.getEncoder.encodeToString(Json.toJson[DisplayClient](client).toString.getBytes)).url,
+            key = "common.cancel",
+            submitClass = Some("govuk-button--secondary")
+        )
+        @submit(messageKey = "save.and.continue.button")
+    </div>
+    }
+}

--- a/app/views/group_member_details/update_client_reference_complete.scala.html
+++ b/app/views/group_member_details/update_client_reference_complete.scala.html
@@ -36,7 +36,7 @@ clientRef: String)(implicit request: Request[_], msgs: Messages, appConfig: AppC
     @msgs("client-reference.updated.panel", clientRef)
 }
 
-@layout(title = msgs("client-reference.updated.panel", clientRef)) {
+@layout(title = msgs("client-reference.updated.title")) {
 
     @govukPanel(
         Panel(title = HtmlContent(panelContent))

--- a/app/views/group_member_details/update_client_reference_complete.scala.html
+++ b/app/views/group_member_details/update_client_reference_complete.scala.html
@@ -17,17 +17,29 @@
 @import config.AppConfig
 @import controllers.routes
 @import views.html.main_layout
+@import utils.ViewUtils._
 
-
-@this(layout: main_layout, p: p, h1: h1, h2: h2, a: a, govukPanel: GovukPanel)
+@this(
+layout: main_layout,
+p: p, h1: h1, h2: h2, a: a,
+caption: caption,
+govukPanel: GovukPanel)
 
 @(client: DisplayClient,
 clientRef: String)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
 
+@panelContent = {
+    @caption(
+        key=msgs("update-client-reference.caption", displayObfuscatedReference(clientRef, client.hmrcRef)),
+        classes=Some("govuk-panel--confirmation")
+    )
+    @msgs("client-reference.updated.panel", clientRef)
+}
+
 @layout(title = msgs("client-reference.updated.panel", clientRef)) {
 
     @govukPanel(
-        Panel(title = Text(msgs("client-reference.updated.panel", clientRef)))
+        Panel(title = HtmlContent(panelContent))
     )
 
     @h2("common.what.happens.next")

--- a/app/views/group_member_details/update_client_reference_complete.scala.html
+++ b/app/views/group_member_details/update_client_reference_complete.scala.html
@@ -1,0 +1,39 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import controllers.routes
+@import views.html.main_layout
+
+
+@this(layout: main_layout, p: p, h1: h1, h2: h2, a: a, govukPanel: GovukPanel)
+
+@(client: DisplayClient,
+clientRef: String)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+
+@layout(title = msgs("client-reference.updated.panel", clientRef)) {
+
+    @govukPanel(
+        Panel(title = Text(msgs("client-reference.updated.panel", clientRef)))
+    )
+
+    @h2("common.what.happens.next")
+    @p("client-reference.updated.p")
+    @a( "common.return.manage-clients",
+        id = Some("returnToManageClients"),
+        href = routes.ManageClientController.showAllClients.url)
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -47,7 +47,7 @@ POST    /group/check-your-answers                   controllers.GroupController.
 
 GET     /group/group-created                        controllers.GroupController.showGroupCreated
 
-# manage groups
+# Manage groups
 GET     /manage-access-groups                       controllers.ManageGroupController.showManageGroups
 POST    /manage-access-groups                       controllers.ManageGroupController.submitAddUnassignedClients
 POST    /manage-access-groups/search                controllers.ManageGroupController.submitFilterByGroupName
@@ -57,7 +57,6 @@ GET     /update-group-clients/:groupId              controllers.ManageGroupContr
 POST    /update-group-clients/:groupId              controllers.ManageGroupController.submitManageGroupClients(groupId: String)
 GET     /update-group-clients/review/:groupId       controllers.ManageGroupController.showReviewSelectedClients(groupId: String)
 GET     /clients-updated/:groupId                   controllers.ManageGroupController.showGroupClientsUpdatedConfirmation(groupId: String)
-
 
 GET     /manage-group-team-members/:groupId         controllers.ManageGroupController.showExistingGroupTeamMembers(groupId: String)
 GET     /update-group-team-members/:groupId         controllers.ManageGroupController.showManageGroupTeamMembers(groupId: String)
@@ -69,19 +68,21 @@ GET     /rename-group/:groupId                      controllers.ManageGroupContr
 POST    /rename-group/:groupId                      controllers.ManageGroupController.submitRenameGroup(groupId: String)
 GET     /access-group-renamed/:groupId              controllers.ManageGroupController.showGroupRenamed(groupId: String)
 
-#UNASSIGNED CLIENTS
-
-GET     /manage-access-group/unassigned-clients-selected        controllers.ManageGroupController.showSelectedUnassignedClients
-GET     /manage-access-group/unassigned-clients-select-group    controllers.ManageGroupController.showSelectGroupsForSelectedUnassignedClients
-POST    /manage-access-group/unassigned-clients-select-group    controllers.ManageGroupController.submitSelectGroupsForSelectedUnassignedClients
-GET    /manage-access-group/clients-assigned                    controllers.ManageGroupController.showConfirmClientsAddedToGroups
-
-
 GET     /delete-group/:groupId                      controllers.ManageGroupController.showDeleteGroup(groupId: String)
 POST    /delete-group/:groupId                      controllers.ManageGroupController.submitDeleteGroup(groupId: String)
 GET     /access-group-deleted                       controllers.ManageGroupController.showGroupDeleted
 
-# manage clients
-GET     /manage-clients                             controllers.ManageClientController.showAllClients
-POST    /manage-clients                             controllers.ManageClientController.submitFilterAllClients
-GET     /manage-clients/client-details/:clientId    controllers.ManageClientController.showClientDetails(clientId: String)
+# UNASSIGNED CLIENTS
+GET     /manage-access-group/unassigned-clients-selected        controllers.ManageGroupController.showSelectedUnassignedClients
+GET     /manage-access-group/unassigned-clients-select-group    controllers.ManageGroupController.showSelectGroupsForSelectedUnassignedClients
+POST    /manage-access-group/unassigned-clients-select-group    controllers.ManageGroupController.submitSelectGroupsForSelectedUnassignedClients
+GET     /manage-access-group/clients-assigned                   controllers.ManageGroupController.showConfirmClientsAddedToGroups
+
+# Manage clients
+GET     /manage-clients                                                     controllers.ManageClientController.showAllClients
+POST    /manage-clients                                                     controllers.ManageClientController.submitFilterAllClients
+GET     /manage-clients/client-details/:clientId                            controllers.ManageClientController.showClientDetails(clientId: String)
+
+GET     /manage-clients/client-details/update-client-reference/:clientId    controllers.ManageClientController.showUpdateClientReference(clientId: String)
+POST    /manage-clients/client-details/update-client-reference/:clientId    controllers.ManageClientController.submitUpdateClientReference(clientId: String)
+GET     /manage-clients/client-details/client-reference-updated/:clientId   controllers.ManageClientController.showClientReferenceUpdatedComplete(clientId: String)

--- a/conf/messages
+++ b/conf/messages
@@ -184,17 +184,19 @@ details.clients.no-data=We could not retrieve this
 details.team-members=Team member details
 details.link-hidden= for {0}
 
-update-client-reference=Update client reference
-update-client-reference.caption=Tax reference: {0}
-update-client-reference.label=Client reference
-update-client-reference.inset=Please note that adding a client reference here does not update the client’s details in the Government Gateway account. It only affects the client reference in your access groups.
-
-client-reference.updated.panel=Client reference updated to {0}
-client-reference.updated.p=You have updated this client reference in your access groups. This will not change the client reference in other Government Gateway services.
-
 common.details.assign-to-group=Assign to an access group
 common.details.not-assigned=Not assigned to an access group
 common.details.groups.header=Member of these groups
+
+update-client-reference=Update client reference
+update-client-reference.caption=Tax reference: {0}
+update-client-reference.label=Client reference
+update-client-reference.text=Please note that adding a client reference here does not update the client’s details in the Government Gateway account. It only affects the client reference in your access groups.
+error.client-reference.required=Enter client reference
+error.client-reference.max-length=Client reference must be 80 characters or fewer
+
+client-reference.updated.panel=Client reference updated to {0}
+client-reference.updated.p=You have updated this client reference in your access groups. This will not change the client reference in other Government Gateway services.
 
 error.group.filter.max.length=You can only enter 32 characters or fewer
 error.group.filter.required=You must enter a group name or part of it

--- a/conf/messages
+++ b/conf/messages
@@ -195,6 +195,7 @@ update-client-reference.text=Please note that adding a client reference here doe
 error.client-reference.required=Enter client reference
 error.client-reference.max-length=Client reference must be 80 characters or fewer
 
+client-reference.updated.title=Client reference updated
 client-reference.updated.panel=Client reference updated to {0}
 client-reference.updated.p=You have updated this client reference in your access groups. This will not change the client reference in other Government Gateway services.
 

--- a/conf/messages
+++ b/conf/messages
@@ -8,15 +8,15 @@ common.errorSummary.heading=There is a problem
 common.yes.label=Yes
 common.no.label=No
 common.caption.group.name={0} access group
-continue=Continue
-common.what.happens.next=What happens next?
+common.continue=Continue
+common.what.happens.next=What happens next
 common.change=Change
 common.actions=Actions
 common.update=Update
 common.clients=Clients
 common.teamMembers=Team members
+common.cancel=Cancel
 
-continue.button=Continue
 save.and.continue.button=Save and continue
 submit.button=Submit
 
@@ -183,6 +183,14 @@ details.clients=Client details
 details.clients.no-data=We could not retrieve this
 details.team-members=Team member details
 details.link-hidden= for {0}
+
+update-client-reference=Update client reference
+update-client-reference.caption=Tax reference: {0}
+update-client-reference.label=Client reference
+update-client-reference.inset=Please note that adding a client reference here does not update the client’s details in the Government Gateway account. It only affects the client reference in your access groups.
+
+client-reference.updated.panel=Client reference updated to {0}
+client-reference.updated.p=You have updated this client reference in your access groups. This will not change the client reference in other Government Gateway services.
 
 common.details.assign-to-group=Assign to an access group
 common.details.not-assigned=Not assigned to an access group

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -10,7 +10,7 @@ common.yes.label=Yes
 common.no.label=No
 common.caption.group.name={0} access group
 continue=Continue
-common.what.happens.next=What happens next?
+common.what.happens.next=What happens next
 common.change=Change
 
 continue.button=Continue

--- a/test/connectors/AgentUserClientDetailsConnectorSpec.scala
+++ b/test/connectors/AgentUserClientDetailsConnectorSpec.scala
@@ -25,6 +25,8 @@ import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Client, UserDetails}
 import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
 
+import scala.concurrent.Future
+
 class AgentUserClientDetailsConnectorSpec
     extends BaseSpec
     with HttpClientMocks
@@ -128,7 +130,7 @@ class AgentUserClientDetailsConnectorSpec
 
   "updateClientReference" should {
 
-    "return Done when response code is OK" in {
+    "return Future[Done] when response code is NO_CONTENT" in {
 
       val clientRequest = Client("HMRC-MTD-VAT~VRN~123456789", "new friendly name")
       val url = s"http://localhost:9449/agent-user-client-details/arn/${arn.value}/update-friendly-name"
@@ -136,7 +138,7 @@ class AgentUserClientDetailsConnectorSpec
       mockHttpPUT[Client, HttpResponse](url,
         clientRequest,
         mockResponse)
-      connector.updateClientReference(arn, clientRequest) shouldBe Done
+      connector.updateClientReference(arn, clientRequest).futureValue shouldBe Done
     }
 
     "throw exception when it fails" in {

--- a/test/connectors/AgentUserClientDetailsConnectorSpec.scala
+++ b/test/connectors/AgentUserClientDetailsConnectorSpec.scala
@@ -16,10 +16,11 @@
 
 package connectors
 
+import akka.Done
 import com.google.inject.AbstractModule
 import helpers.{AgentUserClientDetailsConnectorMocks, BaseSpec, HttpClientMocks}
 import play.api.Application
-import play.api.http.Status.{ACCEPTED, OK}
+import play.api.http.Status.{ACCEPTED, INTERNAL_SERVER_ERROR, NO_CONTENT, OK}
 import play.api.test.Helpers.{await, defaultAwaitTimeout}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Client, UserDetails}
 import uk.gov.hmrc.http.{HttpClient, HttpResponse, UpstreamErrorResponse}
@@ -124,4 +125,36 @@ class AgentUserClientDetailsConnectorSpec
     }
   }
 
+
+  "updateClientReference" should {
+
+    "return Done when response code is OK" in {
+
+      val clientRequest = Client("HMRC-MTD-VAT~VRN~123456789", "new friendly name")
+      val url = s"http://localhost:9449/agent-user-client-details/arn/${arn.value}/update-friendly-name"
+      val mockResponse = HttpResponse.apply(NO_CONTENT, "")
+      mockHttpPUT[Client, HttpResponse](url,
+        clientRequest,
+        mockResponse)
+      connector.updateClientReference(arn, clientRequest) shouldBe Done
+    }
+
+    "throw exception when it fails" in {
+
+      val clientRequest = Client("HMRC-MTD-VAT~VRN~123456789", "new friendly name")
+      val url = s"http://localhost:9449/agent-user-client-details/arn/${arn.value}/update-friendly-name"
+      val mockResponse = HttpResponse.apply(INTERNAL_SERVER_ERROR, "")
+      mockHttpPUT[Client, HttpResponse](url,
+        clientRequest,
+        mockResponse)
+
+      //then
+      val caught = intercept[UpstreamErrorResponse] {
+        await(connector.updateClientReference(arn, clientRequest))
+      }
+      caught.statusCode shouldBe INTERNAL_SERVER_ERROR
+    }
+
+
+  }
 }

--- a/test/controllers/GroupControllerSpec.scala
+++ b/test/controllers/GroupControllerSpec.scala
@@ -1490,7 +1490,7 @@ class GroupControllerSpec extends BaseSpec {
       html
         .select(Css.confirmationPanelBody)
         .text() shouldBe "XYZ access group is now active"
-      html.select(Css.H2).text() shouldBe "What happens next?"
+      html.select(Css.H2).text() shouldBe "What happens next"
       html.select(Css.backLink).size() shouldBe 0
 
       html

--- a/test/controllers/ManageClientControllerSpec.scala
+++ b/test/controllers/ManageClientControllerSpec.scala
@@ -49,7 +49,7 @@ class ManageClientControllerSpec extends BaseSpec {
   lazy val sessionCacheRepo: SessionCacheRepository =
     new SessionCacheRepository(mongoComponent, timestampSupport)
 
-  override def moduleWithOverrides = new AbstractModule() {
+  override def moduleWithOverrides: AbstractModule = new AbstractModule() {
 
     override def configure(): Unit = {
       bind(classOf[AuthAction])
@@ -298,6 +298,112 @@ class ManageClientControllerSpec extends BaseSpec {
 
       html.body.text().contains("Not assigned to an access group")
 
+    }
+
+  }
+
+  s"GET ${routes.ManageClientController.showUpdateClientReference(clientId).url}" should {
+
+    "render update_client_details with existing client reference" in {
+      //given
+      expectAuthorisationGrantsAccess(mockedAuthResponse)
+      stubOptInStatusOk(arn)(OptedInReady)
+      expectGetGroupsForClientSuccess(arn, enrolment, None)
+
+      //when
+      val result = controller.showUpdateClientReference(clientId)(request)
+
+      //then
+      status(result) shouldBe OK
+      val html = Jsoup.parse(contentAsString(result))
+
+      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
+      html.select(H1).text() shouldBe "Update client reference"
+
+      html.body.text().contains("Not assigned to an access group")
+    }
+
+    "render update_client_details without a client reference" in {
+      //given
+      expectAuthorisationGrantsAccess(mockedAuthResponse)
+      stubOptInStatusOk(arn)(OptedInReady)
+      expectGetGroupsForClientSuccess(arn, enrolment, Some(groupSummaries))
+
+      //when
+      val result = controller.showUpdateClientReference(clientId)(request)
+
+      //then
+      status(result) shouldBe OK
+      val html = Jsoup.parse(contentAsString(result))
+
+      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
+      html.select(H1).text() shouldBe "Update client reference"
+
+      html.body.text().contains("Not assigned to an access group")
+
+    }
+
+  }
+
+  s"POST ${routes.ManageClientController.submitUpdateClientReference(clientId).url}" should {
+
+    "save client reference" in {
+      //given
+      expectAuthorisationGrantsAccess(mockedAuthResponse)
+      stubOptInStatusOk(arn)(OptedInReady)
+      expectGetGroupsForClientSuccess(arn, enrolment, None)
+
+      //when
+      val result = controller.showUpdateClientReference(clientId)(request)
+
+      //then
+      status(result) shouldBe OK
+      val html = Jsoup.parse(contentAsString(result))
+
+    }
+
+    "redirect to update_client_details and display errors" in {
+      //given
+      expectAuthorisationGrantsAccess(mockedAuthResponse)
+      stubOptInStatusOk(arn)(OptedInReady)
+      expectGetGroupsForClientSuccess(arn, enrolment, Some(groupSummaries))
+
+      //when
+      val result = controller.showUpdateClientReference(clientId)(request)
+
+      //then
+      status(result) shouldBe OK
+      val html = Jsoup.parse(contentAsString(result))
+
+      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
+      html.select(H1).text() shouldBe "Update client reference"
+
+      html.body.text().contains("Not assigned to an access group")
+
+    }
+
+  }
+
+
+  s"GET ${routes.ManageClientController.showClientReferenceUpdatedComplete(clientId).url}" should {
+
+    "render client_details_complete with existing client reference" in {
+      //given
+      expectAuthorisationGrantsAccess(mockedAuthResponse)
+      stubOptInStatusOk(arn)(OptedInReady)
+      expectGetGroupsForClientSuccess(arn, enrolment, None)
+
+      //when
+      val result = controller.showClientReferenceUpdatedComplete(clientId)(request)
+
+      //then
+      status(result) shouldBe OK
+      val html = Jsoup.parse(contentAsString(result))
+
+      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
+      html.select(H1).text() shouldBe "Update client reference"
+
+      html.body.text().contains("Not assigned to an access group")
     }
 
   }

--- a/test/controllers/ManageClientControllerSpec.scala
+++ b/test/controllers/ManageClientControllerSpec.scala
@@ -29,7 +29,7 @@ import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.Helpers.{await, contentAsString, defaultAwaitTimeout, redirectLocation}
 import play.api.test.FakeRequest
 import repository.SessionCacheRepository
-import services.GroupService
+import services.{GroupService, ManageClientService}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Client, Enrolment, Identifier, OptedInReady}
 import uk.gov.hmrc.auth.core.AuthConnector
 import uk.gov.hmrc.http.SessionKeys
@@ -45,6 +45,7 @@ class ManageClientControllerSpec extends BaseSpec {
     : AgentUserClientDetailsConnector =
     mock[AgentUserClientDetailsConnector]
   implicit val mockGroupService: GroupService = mock[GroupService]
+  implicit val mockManageClientService: ManageClientService = mock[ManageClientService]
 
   lazy val sessionCacheRepo: SessionCacheRepository =
     new SessionCacheRepository(mongoComponent, timestampSupport)
@@ -77,6 +78,10 @@ class ManageClientControllerSpec extends BaseSpec {
 
   val fakeClientWithNoFriendlyName: Client = Client(s"HMRC-MTD-VAT~VRN~123456789", "")
 
+  val displayClientWithNoFrieldyName: DisplayClient = DisplayClient.fromClient(fakeClientWithNoFriendlyName)
+
+  val encodedClientWithNoName: String = Base64.getEncoder.encodeToString(Json.toJson(displayClientWithNoFrieldyName).toString.getBytes)
+
   val displayClients: Seq[DisplayClient] =
     fakeClients.map(DisplayClient.fromClient(_))
 
@@ -84,7 +89,7 @@ class ManageClientControllerSpec extends BaseSpec {
     displayClients.map(client =>
       Base64.getEncoder.encodeToString(Json.toJson(client).toString.getBytes))
 
-  val clientId: String = encodedDisplayClients.take(1).head
+  val clientId: String = encodedDisplayClients.head
 
   val groupSummaries = Seq(
     GroupSummary("groupId", "groupName", 33, 9),
@@ -277,7 +282,7 @@ class ManageClientControllerSpec extends BaseSpec {
       html.title() shouldBe "Client details - Manage Agent Permissions - GOV.UK"
       html.select(H1).text() shouldBe "Client details"
 
-      html.body.text().contains("Not assigned to an access group")
+      html.body.text().contains("Not assigned to an access group") shouldBe true
     }
 
     "render the clients details page with list of groups" in {
@@ -296,7 +301,7 @@ class ManageClientControllerSpec extends BaseSpec {
       html.title() shouldBe "Client details - Manage Agent Permissions - GOV.UK"
       html.select(H1).text() shouldBe "Client details"
 
-      html.body.text().contains("Not assigned to an access group")
+      html.body.text().contains("Not assigned to an access group") shouldBe false
 
     }
 
@@ -304,12 +309,10 @@ class ManageClientControllerSpec extends BaseSpec {
 
   s"GET ${routes.ManageClientController.showUpdateClientReference(clientId).url}" should {
 
-    "render update_client_details with existing client reference" in {
+    "render update_client_reference with existing client reference" in {
       //given
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedInReady)
-      expectGetGroupsForClientSuccess(arn, enrolment, None)
-
       //when
       val result = controller.showUpdateClientReference(clientId)(request)
 
@@ -320,17 +323,16 @@ class ManageClientControllerSpec extends BaseSpec {
       html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
       html.select(H1).text() shouldBe "Update client reference"
 
-      html.body.text().contains("Not assigned to an access group")
+      html.body.select("input#clientRef").attr("value") shouldBe "friendly0"
     }
 
-    "render update_client_details without a client reference" in {
+    "render update_client_reference without a client reference" in {
       //given
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedInReady)
-      expectGetGroupsForClientSuccess(arn, enrolment, Some(groupSummaries))
 
       //when
-      val result = controller.showUpdateClientReference(clientId)(request)
+      val result = controller.showUpdateClientReference(encodedClientWithNoName)(request)
 
       //then
       status(result) shouldBe OK
@@ -339,7 +341,7 @@ class ManageClientControllerSpec extends BaseSpec {
       html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
       html.select(H1).text() shouldBe "Update client reference"
 
-      html.body.text().contains("Not assigned to an access group")
+      html.body.select("input#clientRef").attr("value") shouldBe ""
 
     }
 
@@ -347,14 +349,14 @@ class ManageClientControllerSpec extends BaseSpec {
 
   s"POST ${routes.ManageClientController.submitUpdateClientReference(clientId).url}" should {
 
-    "save client reference" in {
+    s"redirect to ${routes.ManageClientController.showClientReferenceUpdatedComplete(clientId)} and save client reference" in {
       //given
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedInReady)
-      expectGetGroupsForClientSuccess(arn, enrolment, None)
+      //await(sessionCacheRepo.putSession(CLIENT_REFERENCE, "The New Name"))
 
       //when
-      val result = controller.showUpdateClientReference(clientId)(request)
+      val result = controller.submitUpdateClientReference(clientId)(request)
 
       //then
       status(result) shouldBe OK
@@ -362,23 +364,20 @@ class ManageClientControllerSpec extends BaseSpec {
 
     }
 
-    "redirect to update_client_details and display errors" in {
+    "display errors for update_client_details" in {
       //given
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedInReady)
-      expectGetGroupsForClientSuccess(arn, enrolment, Some(groupSummaries))
 
       //when
-      val result = controller.showUpdateClientReference(clientId)(request)
+      val result = controller.submitUpdateClientReference(clientId)(request)
 
       //then
       status(result) shouldBe OK
       val html = Jsoup.parse(contentAsString(result))
 
-      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
+      html.title() shouldBe "Error: Update client reference - Manage Agent Permissions - GOV.UK"
       html.select(H1).text() shouldBe "Update client reference"
-
-      html.body.text().contains("Not assigned to an access group")
 
     }
 
@@ -387,11 +386,11 @@ class ManageClientControllerSpec extends BaseSpec {
 
   s"GET ${routes.ManageClientController.showClientReferenceUpdatedComplete(clientId).url}" should {
 
-    "render client_details_complete with existing client reference" in {
+    "render client_details_complete with new client reference" in {
       //given
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       stubOptInStatusOk(arn)(OptedInReady)
-      expectGetGroupsForClientSuccess(arn, enrolment, None)
+      await(sessionCacheRepo.putSession(CLIENT_REFERENCE, "The New Name"))
 
       //when
       val result = controller.showClientReferenceUpdatedComplete(clientId)(request)
@@ -400,10 +399,10 @@ class ManageClientControllerSpec extends BaseSpec {
       status(result) shouldBe OK
       val html = Jsoup.parse(contentAsString(result))
 
-      html.title() shouldBe "Update client reference - Manage Agent Permissions - GOV.UK"
-      html.select(H1).text() shouldBe "Update client reference"
-
-      html.body.text().contains("Not assigned to an access group")
+      html.title() shouldBe "Client reference updated - Manage Agent Permissions - GOV.UK"
+      html
+        .select(Css.confirmationPanelH1)
+        .text() shouldBe "Tax reference: ending in 6780 Client reference updated to The New Name"
     }
 
   }

--- a/test/controllers/ManageGroupControllerSpec.scala
+++ b/test/controllers/ManageGroupControllerSpec.scala
@@ -695,7 +695,7 @@ class ManageGroupControllerSpec extends BaseSpec {
       html
         .select(Css.confirmationPanelBody)
         .text() shouldBe "Previous Name access group renamed to Bananas"
-      html.select(Css.H2).text() shouldBe "What happens next?"
+      html.select(Css.H2).text() shouldBe "What happens next"
       html
         .select(Css.paragraphs)
         .get(0)
@@ -828,7 +828,7 @@ class ManageGroupControllerSpec extends BaseSpec {
       html
         .select(Css.confirmationPanelH1)
         .text() shouldBe "Rubbish access group deleted"
-      html.select(Css.H2).text() shouldBe "What happens next?"
+      html.select(Css.H2).text() shouldBe "What happens next"
       html
         .select(Css.paragraphs)
         .get(0)
@@ -1340,7 +1340,7 @@ class ManageGroupControllerSpec extends BaseSpec {
       html
         .select(Css.confirmationPanelH1)
         .text() shouldBe "Bananas access group clients updated"
-      html.select(Css.H2).text() shouldBe "What happens next?"
+      html.select(Css.H2).text() shouldBe "What happens next"
       html
         .select(Css.paragraphs)
         .get(0)

--- a/test/forms/ClientReferenceFormSpec.scala
+++ b/test/forms/ClientReferenceFormSpec.scala
@@ -32,12 +32,12 @@ class ClientReferenceFormSpec
 
     "be successful when non-empty" in {
       val params = Map(clientReference -> "XYZ")
-      GroupNameForm.form().bind(params).value shouldBe Some("XYZ")
+      ClientReferenceForm.form().bind(params).value shouldBe Some("XYZ")
     }
 
     "have errors when empty" in {
       val params = Map(clientReference -> "   ")
-      val validatedForm = GroupNameForm.form().bind(params)
+      val validatedForm = ClientReferenceForm.form().bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm
         .error(clientReference)
@@ -47,7 +47,7 @@ class ClientReferenceFormSpec
 
     "have errors when length exceeds max allowed characters" in {
       val params = Map(clientReference -> RandomStringUtils.random(81))
-      val validatedForm = GroupNameForm.form().bind(params)
+      val validatedForm = ClientReferenceForm.form().bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm
         .error(clientReference)

--- a/test/forms/ClientReferenceFormSpec.scala
+++ b/test/forms/ClientReferenceFormSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms
+
+import org.apache.commons.lang3.RandomStringUtils
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+
+class ClientReferenceFormSpec
+    extends AnyWordSpec
+    with Matchers
+    with GuiceOneAppPerSuite {
+
+  val clientReference = "name"
+
+  "CreateGroupFrom binding" should {
+
+    "be successful when non-empty" in {
+      val params = Map(clientReference -> "XYZ")
+      GroupNameForm.form().bind(params).value shouldBe Some("XYZ")
+    }
+
+    "have errors when empty" in {
+      val params = Map(clientReference -> "   ")
+      val validatedForm = GroupNameForm.form().bind(params)
+      validatedForm.hasErrors shouldBe true
+      validatedForm
+        .error(clientReference)
+        .get
+        .message shouldBe "error.client-reference.required"
+    }
+
+    "have errors when length exceeds max allowed characters" in {
+      val params = Map(clientReference -> RandomStringUtils.random(81))
+      val validatedForm = GroupNameForm.form().bind(params)
+      validatedForm.hasErrors shouldBe true
+      validatedForm
+        .error(clientReference)
+        .get
+        .message shouldBe "error.client-reference.max-length"
+    }
+  }
+
+}

--- a/test/forms/ClientReferenceFormSpec.scala
+++ b/test/forms/ClientReferenceFormSpec.scala
@@ -26,9 +26,9 @@ class ClientReferenceFormSpec
     with Matchers
     with GuiceOneAppPerSuite {
 
-  val clientReference = "name"
+  val clientReference = "clientRef"
 
-  "CreateGroupFrom binding" should {
+  "ClientReferenceForm binding" should {
 
     "be successful when non-empty" in {
       val params = Map(clientReference -> "XYZ")

--- a/test/helpers/HttpClientMocks.scala
+++ b/test/helpers/HttpClientMocks.scala
@@ -66,6 +66,17 @@ trait HttpClientMocks extends MockFactory {
       .returns(Future.successful(output))
   }
 
+  def mockHttpPUT[I, O](url: String, input: I, output: O)(
+    implicit mockHttpClient: HttpClient): Unit = {
+    (mockHttpClient
+      .PUT(_: String, _: I, _: Seq[(String, String)])(_: Writes[I],
+        _: HttpReads[O],
+        _: HeaderCarrier,
+        _: ExecutionContext))
+      .expects(url, input, *, *, *, *, *)
+      .returns(Future.successful(output))
+  }
+
   def mockHttpPATCH[I, O](url: String, input: I, output: O)(
       implicit mockHttpClient: HttpClient): Unit = {
     (mockHttpClient

--- a/test/services/ManageClientServiceSpec.scala
+++ b/test/services/ManageClientServiceSpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import akka.Done
+import connectors.{AgentPermissionsConnector, AgentUserClientDetailsConnector}
+import controllers.CLIENT_REFERENCE
+import helpers.BaseSpec
+import models.DisplayClient
+import play.api.test.Helpers.{await, defaultAwaitTimeout}
+import repository.SessionCacheRepository
+import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, Client}
+import uk.gov.hmrc.http.HeaderCarrier
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ManageClientServiceSpec extends BaseSpec {
+
+  val mockAgentUserClientDetailsConnector: AgentUserClientDetailsConnector =
+    mock[AgentUserClientDetailsConnector]
+  lazy val sessionCacheRepo: SessionCacheRepository =
+    new SessionCacheRepository(mongoComponent, timestampSupport)
+
+  val mockAgentPermissionsConnector: AgentPermissionsConnector =
+    mock[AgentPermissionsConnector]
+
+  val service =
+    new ManageClientService(mockAgentUserClientDetailsConnector, sessionCacheRepo)
+
+  val fakeClients: Seq[Client] = (1 to 10)
+    .map(i => Client(s"HMRC-MTD-VAT~VRN~12345678$i", s"friendly name $i"))
+
+  val displayClients: Seq[DisplayClient] =
+    fakeClients.map(DisplayClient.fromClient(_))
+
+  "updateClientReference" should {
+    "PUT client to agentUserClientDetailsConnector" in {
+      //given
+      val newName = "The new name"
+      val clientWithNewName = Client("HMRC-MTD-VAT~VRN~123456781", newName)
+      (mockAgentUserClientDetailsConnector
+        .updateClientReference(_: Arn, _:Client)(_: HeaderCarrier, _: ExecutionContext))
+        .expects(arn, clientWithNewName,*,*)
+        .returning(Future successful Done)
+
+      //when
+      val updateRef = await(service.updateClientReference(arn, displayClients.head, newName))
+
+      //then
+      updateRef shouldBe Done
+    }
+  }
+
+  "getNewNameFromSession" should {
+    "Get new name from the session" in {
+      //given
+      await(sessionCacheRepo.putSession(CLIENT_REFERENCE, "new name"))
+
+      //when
+      val maybeNewName: Option[String] =
+        await(service.getNewNameFromSession())
+      val name: String = maybeNewName.get
+
+      //then
+      name shouldBe "new name"
+    }
+  }
+
+
+}


### PR DESCRIPTION
Please squash & merge if you merge.

This updates the client reference, but doesn't update it in the groups that the client is already in.

because we don't refresh all the clients in a group here as Geoff noted yesterday
/agent-permissions/manage-group-clients/:groupId

anywhere we do pull the fresh list you can see the change, even removing and re-adding them fetches the name
so refactoring of getGroups endpoint to refresh names before returning them
`/agent-permissions/groups/${id}` would be the best way to sort this, thoughts?