### PR TITLE
Implements ARN allow list filter and '/arn-allowed' endpoint

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -17,6 +17,7 @@
 package config
 
 import com.google.inject.ImplementedBy
+import play.api.Configuration
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 import javax.inject.{Inject, Singleton}
@@ -38,12 +39,14 @@ trait AppConfig {
   val agentPermissionsBaseUrl: String
   val agentUserClientDetailsBaseUrl: String
   val sessionCacheExpiryDuration: Duration
+  def checkArnAllowList: Boolean
+  def allowedArns: Seq[String]
 }
 
 @Singleton
-class AppConfigImpl @Inject()(val servicesConfig: ServicesConfig)
+class AppConfigImpl @Inject()(val servicesConfig: ServicesConfig, configuration: Configuration)
     extends AppConfig {
-  val appName = servicesConfig.getString("appName")
+  val appName: String = servicesConfig.getString("appName")
   val welshLanguageSupportEnabled: Boolean =
     servicesConfig.getBoolean("features.welsh-language-support")
   val contactFrontendBaseUrl: String =
@@ -60,11 +63,13 @@ class AppConfigImpl @Inject()(val servicesConfig: ServicesConfig)
     "microservice.services.agent-services-account-frontend.external-url")
   val agentServicesAccountManageAccountPath: String = servicesConfig.getString(
     "microservice.services.agent-services-account-frontend.manage-account-path")
-  val agentServicesAccountManageAccountUrl = agentServicesAccountExternalUrl + agentServicesAccountManageAccountPath
+  val agentServicesAccountManageAccountUrl: String = agentServicesAccountExternalUrl + agentServicesAccountManageAccountPath
   val agentPermissionsBaseUrl: String =
     servicesConfig.baseUrl("agent-permissions")
   val agentUserClientDetailsBaseUrl: String =
     servicesConfig.baseUrl("agent-user-client-details")
   val sessionCacheExpiryDuration: Duration =
     servicesConfig.getDuration("mongodb.cache.expiry")
+  override lazy val checkArnAllowList: Boolean = servicesConfig.getBoolean("features.check-arn-allow-list")
+  override lazy val allowedArns: Seq[String] = configuration.get[Seq[String]]("allowed.arns")
 }

--- a/app/controllers/ArnAllowListController.scala
+++ b/app/controllers/ArnAllowListController.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import play.api.Logging
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
+import javax.inject.Inject
+
+class ArnAllowListController @Inject()(mcc: MessagesControllerComponents)
+  extends FrontendController(mcc) with Logging {
+
+  def isArnAllowed: Action[AnyContent] = Action(Ok)
+}

--- a/app/controllers/AuthAction.scala
+++ b/app/controllers/AuthAction.scala
@@ -51,8 +51,7 @@ class AuthAction @Inject()(val authConnector: AuthConnector,
       request: RequestHeader,
       appConfig: AppConfig): Future[Result] = {
 
-    implicit val hc: HeaderCarrier =
-      HeaderCarrierConverter.fromRequestAndSession(request, request.session)
+    implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromRequest(request)
 
     authorised(AuthProviders(GovernmentGateway) and Enrolment(agentEnrolment))
       .retrieve(allEnrolments and credentialRole) {

--- a/app/controllers/AuthAction.scala
+++ b/app/controllers/AuthAction.scala
@@ -18,7 +18,7 @@ package controllers
 
 import config.AppConfig
 import play.api.mvc.Results.{Forbidden, Redirect}
-import play.api.mvc.{Request, Result}
+import play.api.mvc.{RequestHeader, Result}
 import play.api.{Configuration, Environment, Logging}
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
@@ -48,8 +48,8 @@ class AuthAction @Inject()(val authConnector: AuthConnector,
 
   def isAuthorisedAgent(body: Arn => Future[Result])(
       implicit ec: ExecutionContext,
-      request: Request[_],
-      appConfig: AppConfig) = {
+      request: RequestHeader,
+      appConfig: AppConfig): Future[Result] = {
 
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromRequestAndSession(request, request.session)
@@ -74,7 +74,7 @@ class AuthAction @Inject()(val authConnector: AuthConnector,
   }
 
   def handleFailure(
-      implicit request: Request[_],
+      implicit request: RequestHeader,
       appConfig: AppConfig): PartialFunction[Throwable, Result] = {
     case _: NoActiveSession =>
       Redirect(

--- a/app/filters/ArnAllowListFilter.scala
+++ b/app/filters/ArnAllowListFilter.scala
@@ -59,6 +59,5 @@ object ArnAllowListFilter {
     "/admin/metrics",
     "/ping/ping",
     "/agent-permissions/assets/",
-    "/agent-permissions/hmrc-frontend/",
-    "/agent-permissions/arnallowed")
+    "/agent-permissions/hmrc-frontend/")
 }

--- a/app/filters/ArnAllowListFilter.scala
+++ b/app/filters/ArnAllowListFilter.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import akka.stream.Materializer
+import config.AppConfig
+import controllers.AuthAction
+import play.api.Logging
+import play.api.mvc.Results.Forbidden
+import play.api.mvc.{Filter, RequestHeader, Result}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
+class ArnAllowListFilter @Inject()(authAction: AuthAction, appConfig: AppConfig)
+                                  (implicit val mat: Materializer, ec: ExecutionContext)
+  extends Filter with Logging {
+
+  def apply(nextFilter: RequestHeader => Future[Result])(requestHeader: RequestHeader): Future[Result] = {
+    implicit val rh: RequestHeader = requestHeader
+    implicit val ac: AppConfig = appConfig
+
+    if (ArnAllowListFilter.noCheckUriPatterns.exists(requestHeader.path.startsWith(_))) {
+      nextFilter(requestHeader)
+    } else {
+      if (appConfig.checkArnAllowList) {
+        authAction.isAuthorisedAgent { arn =>
+          if (appConfig.allowedArns.contains(arn.value)) {
+            nextFilter(requestHeader)
+          } else {
+            logger.error(s"'${arn.value}' is not in allowed ARN list, cannot access '${requestHeader.path}'")
+            Future successful Forbidden
+          }
+        }
+      } else {
+        nextFilter(requestHeader)
+      }
+    }
+  }
+
+}
+
+object ArnAllowListFilter {
+  lazy val noCheckUriPatterns: Seq[String] = Seq(
+    "/admin/metrics",
+    "/ping/ping",
+    "/agent-permissions/assets/",
+    "/agent-permissions/hmrc-frontend/",
+    "/agent-permissions/arnallowed")
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -89,3 +89,5 @@ GET     /manage-clients/client-details/client-reference-updated/:clientId   cont
 GET     /manage-team-members                                                     controllers.ManageTeamMemberController.showAllTeamMembers
 GET     /manage-team-members/team-member-details/:memberId                       controllers.ManageTeamMemberController.showTeamMemberDetails(memberId: String)
 
+# ARN Allow List
+GET     /arn-allowed                                                         controllers.ArnAllowListController.isArnAllowed

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -140,8 +140,14 @@ mongodb {
 play.i18n.langCookieHttpOnly: "true"
 
 # Change this value to true to enable Welsh translations to be loaded from messages.cy, and to display the language toggle
-features.welsh-language-support = true
+features {
+  welsh-language-support = true
+  check-arn-allow-list = false
+}
 
+allowed.arns = []
+
+play.filters.enabled += filters.ArnAllowListFilter
 
 # Replace play.i18n.langs with the commented out line below when your service has been fully translated into Welsh
 # to enable Welsh translations for all content, including the standard headers and footers.

--- a/conf/logback-test.xml
+++ b/conf/logback-test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>ERROR</level>
+        </filter>
+        <encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <pattern>[%level] %message %replace(exception=[%xException]){'^exception=\[\]$',''} %date{ISO8601} %n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="com.google.inject" level="OFF"/>
+    <logger name="org.asynchttpclient.netty" level="OFF"/>
+    <logger name="io.netty.buffer" level="OFF"/>
+    <logger name="play.core.netty" level="OFF"/>
+
+    <root level="DEBUG">
+        <!-- We send DEBUG logs to an ERROR-filtering appender rather than setting log level to ERROR directly
+        so that all the logging statements are exercised during tests -->
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/test/controllers/ArnAllowListControllerSpec.scala
+++ b/test/controllers/ArnAllowListControllerSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import helpers.BaseSpec
+import play.api.Application
+import play.api.http.Status.OK
+import play.api.test.FakeRequest
+
+class ArnAllowListControllerSpec extends BaseSpec {
+
+  override implicit lazy val fakeApplication: Application = appBuilder.build()
+
+  val controller: ArnAllowListController = fakeApplication.injector.instanceOf[ArnAllowListController]
+
+  "Is ARN Allowed" should {
+    s"return $OK" in {
+      val result = controller.isArnAllowed()(FakeRequest())
+      status(result) shouldBe OK
+    }
+  }
+
+}

--- a/test/filters/ArnAllowListFilterSpec.scala
+++ b/test/filters/ArnAllowListFilterSpec.scala
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package filters
+
+import akka.stream.Materializer
+import akka.stream.testkit.NoMaterializer
+import com.google.inject.AbstractModule
+import config.AppConfig
+import controllers.AuthAction
+import helpers.BaseSpec
+import org.scalamock.handlers.CallHandler0
+import play.api.Application
+import play.api.mvc.Results.{Forbidden, Ok}
+import play.api.mvc.{RequestHeader, Result}
+import play.api.test.FakeRequest
+import uk.gov.hmrc.auth.core.{AuthConnector, InsufficientEnrolments}
+
+import scala.concurrent.Future
+
+class ArnAllowListFilterSpec extends BaseSpec {
+
+  implicit val mockAuthConnector: AuthConnector = mock[AuthConnector]
+  implicit val mockAppConfig: AppConfig = mock[AppConfig]
+
+  implicit val materializer: Materializer = NoMaterializer
+
+  val authAction: AuthAction = fakeApplication.injector.instanceOf[AuthAction]
+
+  val filter: ArnAllowListFilter = new ArnAllowListFilter(authAction, mockAppConfig)
+
+  def mockAppConfigCheckArnAllowList(toCheckArnAllowList: Boolean): CallHandler0[Boolean] =
+    (() => mockAppConfig.checkArnAllowList)
+      .expects().returning(toCheckArnAllowList)
+
+  def mockAppConfigAllowedArns(allowedArns: Seq[String]): CallHandler0[Seq[String]] =
+    (() => mockAppConfig.allowedArns)
+      .expects().returning(allowedArns)
+
+  override def moduleWithOverrides: AbstractModule = new AbstractModule() {
+    override def configure(): Unit = {
+      bind(classOf[AuthConnector]).toInstance(mockAuthConnector)
+      bind(classOf[AppConfig]).toInstance(mockAppConfig)
+    }
+  }
+
+  override implicit lazy val fakeApplication: Application = appBuilder.build()
+
+  val nextFilter: RequestHeader => Future[Result] = _ => Future successful Ok
+
+  "Filter" when {
+
+    "requests having URIs that do not need to be checked" should {
+      "be allowed through" in {
+        ArnAllowListFilter.noCheckUriPatterns.map { noCheckUriPattern =>
+          filter(nextFilter)(FakeRequest("GET", noCheckUriPattern)).futureValue shouldBe Ok
+        }
+      }
+    }
+  }
+
+  "requests having URIs that need to be checked" when {
+
+    "feature flag to check for allowed list of ARNs set to false" should {
+      "be allowed through" in {
+        mockAppConfigCheckArnAllowList(toCheckArnAllowList = false)
+
+        filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Ok
+      }
+    }
+
+    "feature flag to check for allowed list of ARNs set to true" when {
+
+      "auth action indicates an exception" should {
+        "not be allowed through" in {
+          mockAppConfigCheckArnAllowList(toCheckArnAllowList = true)
+          expectAuthorisationFails(InsufficientEnrolments())
+
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Forbidden
+        }
+      }
+
+      "allowed list of ARNs contains provided ARN" should {
+        "be allowed through" in {
+
+          mockAppConfigCheckArnAllowList(toCheckArnAllowList = true)
+          expectAuthorisationGrantsAccess(mockedAuthResponse)
+          mockAppConfigAllowedArns(Seq(arn.value))
+
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Ok
+        }
+      }
+
+      "allowed list of ARNs does not contain provided ARN" should {
+        "not be allowed through" in {
+
+          mockAppConfigCheckArnAllowList(toCheckArnAllowList = true)
+          expectAuthorisationGrantsAccess(mockedAuthResponse)
+          mockAppConfigAllowedArns(Seq.empty)
+
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Forbidden
+        }
+      }
+    }
+  }
+
+}

--- a/test/filters/ArnAllowListFilterSpec.scala
+++ b/test/filters/ArnAllowListFilterSpec.scala
@@ -78,7 +78,7 @@ class ArnAllowListFilterSpec extends BaseSpec {
       "be allowed through" in {
         mockAppConfigCheckArnAllowList(toCheckArnAllowList = false)
 
-        filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Ok
+        filter(nextFilter)(FakeRequest("GET", "/agent-permissions/arn-allowed")).futureValue shouldBe Ok
       }
     }
 
@@ -89,7 +89,7 @@ class ArnAllowListFilterSpec extends BaseSpec {
           mockAppConfigCheckArnAllowList(toCheckArnAllowList = true)
           expectAuthorisationFails(InsufficientEnrolments())
 
-          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Forbidden
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/arn-allowed")).futureValue shouldBe Forbidden
         }
       }
 
@@ -100,7 +100,7 @@ class ArnAllowListFilterSpec extends BaseSpec {
           expectAuthorisationGrantsAccess(mockedAuthResponse)
           mockAppConfigAllowedArns(Seq(arn.value))
 
-          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Ok
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/arn-allowed")).futureValue shouldBe Ok
         }
       }
 
@@ -111,7 +111,7 @@ class ArnAllowListFilterSpec extends BaseSpec {
           expectAuthorisationGrantsAccess(mockedAuthResponse)
           mockAppConfigAllowedArns(Seq.empty)
 
-          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/do-you-want-to-opt-in")).futureValue shouldBe Forbidden
+          filter(nextFilter)(FakeRequest("GET", "/agent-permissions/arn-allowed")).futureValue shouldBe Forbidden
         }
       }
     }


### PR DESCRIPTION
- Enable the ARN allow list check by setting config value `features.check-arn-allow-list=true`
- The allowed ARNs can be added in a config array e.g. `allowed.arns.0="NARN000000"`