### PR TITLE
APB-6404 [CS] split dashboard & fix yes/no radios

### DIFF
--- a/app/controllers/UnassignedClientController.scala
+++ b/app/controllers/UnassignedClientController.scala
@@ -19,19 +19,19 @@ package controllers
 import config.AppConfig
 import connectors.{AddMembersToAccessGroupRequest, AgentPermissionsConnector, GroupSummary}
 import forms._
-import models.{ButtonSelect, DisplayClient}
+import models.{AddClientsToGroup, ButtonSelect, DisplayClient}
 import play.api.Logging
 import play.api.data.FormError
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
 import repository.SessionCacheRepository
-import services.{ClientService, SessionCacheService}
+import services.{ClientService, GroupService, SessionCacheService}
 import uk.gov.hmrc.agentmtdidentifiers.model._
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.groups._
 import views.html.groups.manage._
-import views.html.groups.unassigned_clients.select_groups_for_clients
+import views.html.groups.unassigned_clients._
 
 import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
@@ -40,11 +40,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class UnassignedClientController @Inject()(
      authAction: AuthAction,
      mcc: MessagesControllerComponents,
+     groupService: GroupService,
      clientService: ClientService,
      val agentPermissionsConnector: AgentPermissionsConnector,
      val sessionCacheRepository: SessionCacheRepository,
      val sessionCacheService: SessionCacheService,
-     dashboard: dashboard,
+     unassigned_clients_list: unassigned_clients_list,
      review_clients_to_add: review_clients_to_add,
      select_groups_for_clients: select_groups_for_clients,
      clients_added_to_groups_complete: clients_added_to_groups_complete
@@ -61,25 +62,96 @@ class UnassignedClientController @Inject()(
 
   private val controller: ReverseUnassignedClientController = routes.UnassignedClientController
 
+  def showUnassignedClients: Action[AnyContent] = Action.async { implicit request =>
+    isAuthorisedAgent { arn =>
+      isOptedIn(arn) { _ =>
+        withSessionItem[String](CLIENT_FILTER_INPUT) { clientFilterTerm =>
+          withSessionItem[String](CLIENT_SEARCH_INPUT) { clientSearchTerm =>
+            withSessionItem[Boolean](HIDDEN_CLIENTS_EXIST) { maybeHiddenClients =>
+              groupService.groupSummaries(arn).map(gs =>
+                Ok(unassigned_clients_list(
+                    gs,
+                    AddClientsToGroupForm.form().fill(
+                      AddClientsToGroup(
+                        maybeHiddenClients.getOrElse(false),
+                        search = clientSearchTerm,
+                        filter = clientFilterTerm,
+                        clients = None)),
+                    maybeHiddenClients))
+              )
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def submitAddUnassignedClients: Action[AnyContent] = Action.async { implicit request =>
+
+    val encoded = request.body.asFormUrlEncoded
+    val buttonSelection: ButtonSelect = buttonClickedByUserOnFilterFormPage(encoded)
+
+    isAuthorisedAgent { arn =>
+      isOptedInComplete(arn) { _ =>
+        withSessionItem[Seq[DisplayClient]](FILTERED_CLIENTS) { maybeFilteredClients =>
+          withSessionItem[Boolean](HIDDEN_CLIENTS_EXIST) { maybeHiddenClients =>
+            AddClientsToGroupForm
+              .form(buttonSelection)
+              .bindFromRequest()
+              .fold(
+                formWithErrors => {
+                  for {
+                    groupSummaries <- agentPermissionsConnector.groupsSummaries(arn)
+                    _ <- if (buttonSelection == ButtonSelect.Continue) sessionCacheService.clearSelectedClients() else Future.successful(())
+                    result = if (maybeFilteredClients.isDefined)
+                      Ok(unassigned_clients_list(groupSummaries.getOrElse(Seq.empty[GroupSummary], Seq.empty[DisplayClient]), formWithErrors,maybeHiddenClients))
+                    else
+                      Ok(unassigned_clients_list(groupSummaries.getOrElse(Seq.empty[GroupSummary], Seq.empty[DisplayClient]), formWithErrors, maybeHiddenClients))
+                  } yield result
+                },
+                formData => {
+                  // TODO update the filter here, currently filters from a list of ALL clients rather than just unassigned clients
+                  clientService.saveSelectedOrFilteredClients(buttonSelection)(arn)(formData)(clientService.getUnassignedClients).map(_ =>
+                    if(buttonSelection == ButtonSelect.Continue)
+                      Redirect(controller.showSelectedUnassignedClients)
+                    else Redirect(controller.showUnassignedClients)
+                  )
+                }
+              )
+          }
+        }
+      }
+    }
+  }
+
+
   def showSelectedUnassignedClients: Action[AnyContent] = Action.async { implicit request =>
     isAuthorisedAgent { arn =>
       isOptedInComplete(arn) { _ =>
         withSessionItem[Seq[DisplayClient]](SELECTED_CLIENTS) { selectedClients =>
           selectedClients
             .fold {
-              Redirect(routes.ManageGroupController.showManageGroups).toFuture
+              Redirect(controller.showUnassignedClients).toFuture
             } { clients => Ok(
                 review_clients_to_add(
                   clients = clients,
                   groupName = "",
                   form = YesNoForm.form(),
-                  backUrl = Some(s"${routes.ManageGroupController.showManageGroups.url}#unassigned-clients"),
+                  backUrl = Some(controller.showUnassignedClients.url),
                   // TODO needs to be updated to a submit for the yes no form
                   continueCall = controller.showSelectGroupsForSelectedUnassignedClients
                 )
               ).toFuture
             }
         }
+      }
+    }
+  }
+
+  def submitSelectedUnassignedClients: Action[AnyContent] = Action.async { implicit request =>
+    isAuthorisedAgent { arn =>
+      isOptedIn(arn) { _ =>
+        Ok(s"submitSelectedUnassignedClients not yet implemented $arn").toFuture
       }
     }
   }
@@ -145,43 +217,6 @@ class UnassignedClientController @Inject()(
         sessionCacheRepository.getFromSession(GROUPS_FOR_UNASSIGNED_CLIENTS).flatMap {
           case None => Future.successful(Redirect(controller.showSelectGroupsForSelectedUnassignedClients.url))
           case Some(groups) => sessionCacheRepository.deleteFromSession(SELECTED_CLIENTS).map(_ => Ok(clients_added_to_groups_complete(groups)))
-        }
-      }
-    }
-  }
-
-  def submitAddUnassignedClients: Action[AnyContent] = Action.async { implicit request =>
-
-    val encoded = request.body.asFormUrlEncoded
-    val buttonSelection: ButtonSelect = buttonClickedByUserOnFilterFormPage(encoded)
-
-    isAuthorisedAgent { arn =>
-      isOptedInComplete(arn) { _ =>
-        withSessionItem[Seq[DisplayClient]](FILTERED_CLIENTS) { maybeFilteredClients =>
-          withSessionItem[Boolean](HIDDEN_CLIENTS_EXIST) { maybeHiddenClients =>
-            AddClientsToGroupForm
-              .form(buttonSelection)
-              .bindFromRequest()
-              .fold(
-                formWithErrors => {
-                  for {
-                    groupSummaries <- agentPermissionsConnector.groupsSummaries(arn)
-                    _ <- if (buttonSelection == ButtonSelect.Continue) sessionCacheService.clearSelectedClients() else Future.successful(())
-                    result = if (maybeFilteredClients.isDefined)
-                      Ok(dashboard(groupSummaries.getOrElse(Seq.empty[GroupSummary], Seq.empty[DisplayClient]), formWithErrors, FilterByGroupNameForm.form,maybeHiddenClients, showUnassignedClients = true))
-                    else
-                      Ok(dashboard(groupSummaries.getOrElse(Seq.empty[GroupSummary], Seq.empty[DisplayClient]), formWithErrors, FilterByGroupNameForm.form, maybeHiddenClients, showUnassignedClients = true))
-                  } yield result
-                },
-                formData => {
-                  clientService.saveSelectedOrFilteredClients(buttonSelection)(arn)(formData)(clientService.getUnassignedClients).map(_ =>
-                    if(buttonSelection == ButtonSelect.Continue)
-                  Redirect(controller.showSelectedUnassignedClients)
-                    else Redirect(s"${routes.ManageGroupController.showManageGroups}#unassigned-clients")
-                  )
-                }
-              )
-          }
         }
       }
     }

--- a/app/views/groups/manage/clients_added_to_groups_complete.scala.html
+++ b/app/views/groups/manage/clients_added_to_groups_complete.scala.html
@@ -32,7 +32,7 @@
     @ul(items = groupsAddedTo)
     @a( "common.return.to.unassigned.clients",
         id = Some("returnToDashboard"),
-        href = routes.ManageGroupController.showManageGroups.url + "#unassigned-clients"
+        href = routes.UnassignedClientController.showUnassignedClients.url
     )
 
 }

--- a/app/views/groups/manage/dashboard.scala.html
+++ b/app/views/groups/manage/dashboard.scala.html
@@ -24,7 +24,7 @@
 @this(
     layout: main_layout, p: p, h1: h1, h2: h2, h3: h3, a: a, span: span,
     table: table, textbox: textbox, input_select: input_select,
-    a_button: link_as_button,summary_list: summary_list, govukTabs: GovukTabs,
+    a_button: link_as_button,summary_list: summary_list,
     selectable_clients_table_form: selectable_clients_table_form,
         formWithCSRF: FormWithCSRF,
         submit_button_group: submit_button_group,
@@ -33,153 +33,11 @@
 
 @(
     summaries: (Seq[GroupSummary], Seq[DisplayClient]),
-    addClientsToGroupForm: Form[AddClientsToGroup],
-    filterGroupSummaryForm: Form[String],
-    hiddenClientsExist: Option[Boolean],
-    showUnassignedClients: Boolean = false
+    filterGroupSummaryForm: Form[String]
 )(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
 
-
-@groupSummaries = {
-    @h2("group.manage.tabs.1.label")
-    <div class="govuk-!-width-one-third"></div>
-
-    @formWithCSRF(routes.ManageGroupController.submitFilterByGroupName){
-
-        <div class="govuk-grid-row">
-            <div class="govuk-grid-column-one-third">
-            @textbox(
-                field = filterGroupSummaryForm("searchGroupByName"),
-                label = "group-name-filter.text.label",
-                labelClasses = "govuk-label--s",
-                classes = "govuk-input--width-20"
-            )
-            </div>
-            <div class="govuk-grid-column-one-third" id="filter-buttons-wrapper">
-                @submit_button_group(submitId="group-filter-button", secondId="group-clear-button")
-            </div>
-        </div>
-
-    }
-    <hr>
-    @if(summaries._1.nonEmpty){
-
-
-        @summaries._1.map { summary =>
-
-            @h3(summary.groupName)
-            @summary_list(
-                Seq(
-                    SummaryListData(
-                        "common.clients",
-                        summary.clientCount.toString,
-                        routes.ManageGroupClientsController.showExistingGroupClients(summary.groupId),
-                        linkMsgKey = "group.manage.clients",
-                        linkClasses = Some("govuk-!-width-one-half"),
-                        hiddenText = Some(msgs("details.link-hidden", summary.groupName))
-                    ),
-                    SummaryListData(
-                        "common.teamMembers",
-                        summary.teamMemberCount.toString,
-                        routes.ManageGroupTeamMembersController.showExistingGroupTeamMembers(summary.groupId),
-                        linkMsgKey = "group.manage.members",
-                        linkClasses = Some("govuk-!-width-one-half"),
-                        hiddenText = Some(msgs("details.link-hidden", summary.groupName))
-                    ),
-                )
-            )
-            @a(key = msgs("group.manage.rename") + span(classes=Some("govuk-visually-hidden"),
-                key = summary.groupName).toString,
-                href = routes.ManageGroupController.showRenameGroup(summary.groupId).url,
-                classes = Some("govuk-!-margin-right-9"))
-            @a(key = msgs("group.manage.delete") + span(classes=Some("govuk-visually-hidden"),
-                key=summary.groupName).toString,
-                href = routes.ManageGroupController.showDeleteGroup(summary.groupId).url)
-            <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible"
-            style="height: 3px;
-                border-width: 0;
-                color: #c6c6c6;
-                background-color: #c6c6c6">
-
-        }
-
-    }
-    @if(summaries._1.isEmpty){
-        @h3("group.manage.no.groups.h3", classes = Some("govuk-!-margin-top-5"))
-        @p("group.manage.no.groups.p", classes = Some("govuk-!-margin-bottom-8"))
-    }
-
-    @a_button(key="group.manage.no.groups.button", href=routes.CreateGroupController.showGroupName.url)
-
-}
-
-@unassignedClients = {
-    @h2("group.manage.tabs.2.label")
-
-    @if(!summaries._2.isEmpty) {
-        @selectable_clients_table_form(
-            Some(summaries._2),
-            hiddenClientsExist,
-            addClientsToGroupForm,
-            routes.UnassignedClientController.submitAddUnassignedClients
-        )
-
-    }
-    @if(summaries._2.isEmpty) {
-
-        @formWithCSRF(action = routes.UnassignedClientController.submitAddUnassignedClients) {
-            <div class="govuk-grid-row">
-                @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {
-                <div class="govuk-form-group govuk-form-group--error">
-                    }
-
-                    <fieldset class="govuk-fieldset">
-                        <legend class="govuk-fieldset__legend govuk-visually-hidden">
-                            @msgs("filter.legend")
-                        </legend>
-
-                        @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {
-                        <p id="filter-error" class="govuk-error-message">
-                            <span class="govuk-visually-hidden">Error:</span>
-                            @msgs("error.search-filter.empty")
-                        </p>
-                        }
-
-                        <div class="govuk-grid-column-one-quarter">
-                            @textbox(
-                            field = addClientsToGroupForm("search"),
-                            label = "client-filter.text.label",
-                            labelClasses = "govuk-label--s",
-                            classes = "govuk-input--width-20"
-                            )
-                        </div>
-
-                        <div class="govuk-grid-column-one-third govuk-!-padding-top-5">
-                            @input_select(
-                            field = addClientsToGroupForm("filter"),
-                            label = msgs("client-filter.select.label"),
-                            options = getFiltersByTaxService()
-                            )
-                        </div>
-
-                        <div class="govuk-grid-column-one-third govuk-!-padding-top-8">
-                            @submit_button_group(additionalClasses = "govuk-!-margin-bottom-7")
-                        </div>
-                    </fieldset>
-                    @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) { </div> }
-            </div>
-        }
-        @h3("unassigned-clients.not-found.heading")
-        @p("unassigned-clients.not-found.p")
-    }
-}
-
-@errorHref = @{
-if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {"search"} else {"clients"}
-}
-
 @pageTitle = @{
-val errorPrefix = if((!addClientsToGroupForm.errors.isEmpty) || (!filterGroupSummaryForm.errors.isEmpty)) msgs("error-prefix") + " " else ""
+val errorPrefix = if(!filterGroupSummaryForm.errors.isEmpty) msgs("error-prefix") + " " else ""
 errorPrefix.concat(msgs("group.manage.h1"))
 }
 
@@ -187,38 +45,82 @@ errorPrefix.concat(msgs("group.manage.h1"))
     backLinkHref = Some(appConfig.agentServicesAccountManageAccountUrl),
     fullWidth = true) {
 
-
     @h1("group.manage.h1")
-    @p("group.manage.p", classes = Some("govuk-!-margin-bottom-9"), id= Some("info"))
-
+    <div class="govuk-!-width-two-thirds">
+        @p("group.manage.p", classes = Some("govuk-!-margin-bottom-9"), id= Some("info"))
+    </div>
     @summaryErrors(filterGroupSummaryForm.errors, Some("searchGroupByName"))
-    @summaryErrors(addClientsToGroupForm.errors, Some(errorHref))
 
-    @govukTabs(Tabs(
-        id = Some("manage-groups-tabs"),
-        items = Seq(
-            TabItem(
-                id = Some("groups-panel"),
-                label = msgs("group.manage.tabs.1.label"),
-                panel = TabPanel(
-                    content = HtmlContent(groupSummaries)
+    @formWithCSRF(routes.ManageGroupController.submitFilterByGroupName){
+
+        <div class="govuk-grid-row">
+            <div class="govuk-grid-column-one-third">
+                @textbox(
+                field = filterGroupSummaryForm("searchGroupByName"),
+                label = "group-name-filter.text.label",
+                labelClasses = "govuk-label--s",
+                classes = "govuk-input--width-20"
                 )
-            ),
-            TabItem(
-                id = Some("unassigned-clients"),
-                label = msgs("group.manage.tabs.2.label"),
-                panel = TabPanel(content = HtmlContent(unassignedClients))
+            </div>
+            <div class="govuk-grid-column-one-third" id="filter-buttons-wrapper">
+                @submit_button_group(submitId="group-filter-button", secondId="group-clear-button")
+            </div>
+        </div>
+
+    }
+    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" style="height: 3px;
+                        border-width: 0;
+                        color: #c6c6c6;
+                        background-color: #c6c6c6">
+    @if(summaries._1.nonEmpty){
+
+        @summaries._1.map { summary =>
+
+        @h2(summary.groupName)
+        @summary_list(
+            Seq(
+                SummaryListData(
+                    "common.clients",
+                    summary.clientCount.toString,
+                    routes.ManageGroupClientsController.showExistingGroupClients(summary.groupId),
+                    linkMsgKey = "group.manage.clients",
+                    linkClasses = Some("govuk-!-width-one-half"),
+                    hiddenText = Some(msgs("details.link-hidden", summary.groupName))
+                ),
+                SummaryListData(
+                    "common.teamMembers",
+                    summary.teamMemberCount.toString,
+                    routes.ManageGroupTeamMembersController.showExistingGroupTeamMembers(summary.groupId),
+                    linkMsgKey = "group.manage.members",
+                    linkClasses = Some("govuk-!-width-one-half"),
+                    hiddenText = Some(msgs("details.link-hidden", summary.groupName))
+                ),
             )
         )
-    ))
+
+        @a(key = msgs("group.manage.rename") + span(classes=Some("govuk-visually-hidden"),
+        key = summary.groupName).toString,
+        href = routes.ManageGroupController.showRenameGroup(summary.groupId).url,
+        classes = Some("govuk-!-margin-right-9"))
+
+        @a(key = msgs("group.manage.delete") + span(classes=Some("govuk-visually-hidden"),
+        key=summary.groupName).toString,
+        href = routes.ManageGroupController.showDeleteGroup(summary.groupId).url)
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible" style="height: 3px;
+                        border-width: 0;
+                        color: #c6c6c6;
+                        background-color: #c6c6c6">
+
+        }
+
+    } else {
+        @h2("group.manage.no.groups.h3", classes = Some("govuk-!-margin-top-5"))
+        @p("group.manage.no.groups.p", classes = Some("govuk-!-margin-bottom-8"))
+    }
+
+    @a_button(key="group.manage.no.groups.button", href=routes.CreateGroupController.showGroupName.url)
 
 
 }
-@if(showUnassignedClients){
-    <script @{CSPNonce.attr}>
-        $(document).ready(function(){
-            $(".govuk-tabs__list-item").toggleClass("govuk-tabs__list-item--selected");
-            $(".govuk-tabs__panel").toggleClass("govuk-tabs__panel--hidden");
-        });
-    </script>
-}
+

--- a/app/views/groups/review_clients_to_add.scala.html
+++ b/app/views/groups/review_clients_to_add.scala.html
@@ -53,10 +53,9 @@
     @layout(
         title = msgs("group.clients.review.title", groupName),
         backLinkHref = backUrl,
+        formErrors = form.errors,
         fullWidth = true
     ) {
-
-    @summaryErrors(form.errors)
 
         <div class="govuk-!-width-two-thirds">
             @if(groupName != ""){

--- a/app/views/groups/unassigned_clients/unassigned_clients_list.scala.html
+++ b/app/views/groups/unassigned_clients/unassigned_clients_list.scala.html
@@ -1,0 +1,119 @@
+@*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import connectors.GroupSummary
+@import views.components.models.SummaryListData
+@import views.html.main_layout
+@import views.html.partials.selectable_clients_table_form
+@import views.html.helper.CSPNonce
+@import utils.ViewUtils._
+
+@this(
+    layout: main_layout,
+    p: p, h1: h1, h2: h2, h3: h3, a: a, span: span, inset_text: inset_text,
+    table: table, textbox: textbox, input_select: input_select,
+    a_button: link_as_button,summary_list: summary_list,
+    selectable_clients_table_form: selectable_clients_table_form,
+        formWithCSRF: FormWithCSRF,
+        submit_button_group: submit_button_group,
+        summaryErrors: SummaryErrors
+)
+
+@(
+    summaries: (Seq[GroupSummary], Seq[DisplayClient]),
+    addClientsToGroupForm: Form[AddClientsToGroup],
+    hiddenClientsExist: Option[Boolean]
+)(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
+
+@errorHref = @{
+if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {"search"} else {"clients"}
+}
+
+@pageTitle = @{
+val errorPrefix = if(!addClientsToGroupForm.errors.isEmpty) msgs("error-prefix") + " " else ""
+errorPrefix.concat(msgs("group.manage.tabs.2.label"))
+}
+
+@layout(title = pageTitle,
+    backLinkHref = Some(appConfig.agentServicesAccountManageAccountUrl),
+    fullWidth = true) {
+
+    @h1("group.manage.tabs.2.label")
+    <div class="govuk-!-width-two-thirds">
+        @inset_text("unassigned.client.list.p", classes = "govuk-!-margin-bottom-9", id= Some("info"))
+    </div>
+
+    @summaryErrors(addClientsToGroupForm.errors, Some(errorHref))
+
+    @if(!summaries._2.isEmpty) {
+        @selectable_clients_table_form(
+            Some(summaries._2),
+            hiddenClientsExist,
+            addClientsToGroupForm,
+            routes.UnassignedClientController.submitAddUnassignedClients
+        )
+    } else {
+
+        @formWithCSRF(action = routes.UnassignedClientController.submitAddUnassignedClients) {
+        <div class="govuk-grid-row">
+            @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {
+            <div class="govuk-form-group govuk-form-group--error">
+            }
+
+                <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-visually-hidden">
+                        @msgs("filter.legend")
+                    </legend>
+
+                    @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) {
+                    <p id="filter-error" class="govuk-error-message">
+                        <span class="govuk-visually-hidden">Error:</span>
+                        @msgs("error.search-filter.empty")
+                    </p>
+                    }
+
+                    <div class="govuk-grid-column-one-quarter">
+                        @textbox(
+                        field = addClientsToGroupForm("search"),
+                        label = "client-filter.text.label",
+                        labelClasses = "govuk-label--s",
+                        classes = "govuk-input--width-20"
+                        )
+                    </div>
+
+                    <div class="govuk-grid-column-one-third govuk-!-padding-top-5">
+                        @input_select(
+                        field = addClientsToGroupForm("filter"),
+                        label = msgs("client-filter.select.label"),
+                        options = getFiltersByTaxService()
+                        )
+                    </div>
+
+                    <div class="govuk-grid-column-one-third govuk-!-padding-top-8">
+                        @submit_button_group(additionalClasses = "govuk-!-margin-bottom-7")
+                    </div>
+                </fieldset>
+                @if(addClientsToGroupForm.errors.map(error => error.message).contains("error.search-filter.empty")) { </div> }
+        </div>
+        }
+
+        @h3("unassigned-clients.not-found.heading")
+        @p("unassigned-clients.not-found.p")
+
+    }
+
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -77,8 +77,10 @@ GET     /team-members-updated/:groupId      controllers.ManageGroupTeamMembersCo
 
 
 # UNASSIGNED CLIENTS
-POST    /manage-access-groups                                   controllers.UnassignedClientController.submitAddUnassignedClients
+GET     /unassigned-clients                                     controllers.UnassignedClientController.showUnassignedClients
+POST    /unassigned-clients                                     controllers.UnassignedClientController.submitAddUnassignedClients
 GET     /manage-access-group/unassigned-clients-selected        controllers.UnassignedClientController.showSelectedUnassignedClients
+POST    /manage-access-group/unassigned-clients-selected        controllers.UnassignedClientController.submitSelectedUnassignedClients
 GET     /manage-access-group/unassigned-clients-select-group    controllers.UnassignedClientController.showSelectGroupsForSelectedUnassignedClients
 POST    /manage-access-group/unassigned-clients-select-group    controllers.UnassignedClientController.submitSelectGroupsForSelectedUnassignedClients
 GET     /manage-access-group/clients-assigned                   controllers.UnassignedClientController.showConfirmClientsAddedToGroups

--- a/conf/messages
+++ b/conf/messages
@@ -157,7 +157,7 @@ group.created.panelContent={0} access group is now active
 group.created.p=The team members you selected can now view and manage the tax affairs of all the clients in this access group
 
 group.manage.h1=Manage access groups
-group.manage.p=The team members in the group will be able to manage the tax affairs of clients in the group
+group.manage.p=The team members in the group will be able to manage the tax affairs of clients in the group.
 group.manage.tabs.1.label=Access groups
 group.manage.tabs.2.label=Unassigned clients
 
@@ -198,6 +198,7 @@ group.manage.confirm.updated.clients.p=You have changed the clients that can be 
 group.manage.confirm.updated.team-members.h1={0} access group team members updated
 group.manage.confirm.updated.team-members.p=The team members you selected can view and manage the tax affairs of all the clients in this access group.
 
+unassigned.client.list.p=These clients are visible to all team members.
 unassigned.client.assign.hint=Select all that apply
 unassigned.client.assign.h1=Which access groups would you like to add the selected clients to?
 unassigned.client.assign.existing.or.new.error=You cannot add to existing groups at the same time as creating a new group

--- a/project/CodeCoverageSettings.scala
+++ b/project/CodeCoverageSettings.scala
@@ -28,6 +28,7 @@ object CodeCoverageSettings {
     ".*manage_team_members_list.template",
     ".*confirm_added.template",
     ".*group_not_found.template",
+    ".*unassigned_clients_list.template",
     ".*ViewUtils.*",
     ".*GroupAction.*",
     ".*ClientAction.*",

--- a/test/controllers/CreateGroupControllerSpec.scala
+++ b/test/controllers/CreateGroupControllerSpec.scala
@@ -923,7 +923,7 @@ class CreateGroupControllerSpec extends BaseSpec {
 
       status(result) shouldBe OK
       val html = Jsoup.parse(contentAsString(result))
-      html.title() shouldBe "Review selected clients - Agent services account - GOV.UK"
+      html.title() shouldBe "Error: Review selected clients - Agent services account - GOV.UK"
       html.select(H1).text() shouldBe "You have selected 3 clients"
       html.select(Css.errorSummaryForField("answer")).text() shouldBe "Select an option"
       html.select(Css.errorForField("answer")).text() shouldBe "Error: Select an option"


### PR DESCRIPTION
- tabs are now two separate pages both accessed from different links on ASAF 'Manage account' page (see PR https://github.com/hmrc/agent-services-account-frontend/pull/282)
- fix routing on yes/no radios for unassigned clients