### PR TITLE
apb-6440 [CS] remove escaped \ from regex

### DIFF
--- a/app/forms/ClientReferenceForm.scala
+++ b/app/forms/ClientReferenceForm.scala
@@ -22,7 +22,7 @@ import play.api.data.Forms._
 
 object ClientReferenceForm {
 
-  val friendlyNameRegex = "^[!%*^()_+\\\\\\-={}:;@~#,.?\\\\[\\\\]\\/A-Za-z0-9]{0,}$"
+  val friendlyNameRegex = "^[!%*^()_+\\-={}:;@~#,.?\\[\\]/A-Za-z0-9 ]{0,}$"
 
   def form(): Form[String] = {
     Form(

--- a/app/forms/ConfirmCreateGroupForm.scala
+++ b/app/forms/ConfirmCreateGroupForm.scala
@@ -22,7 +22,7 @@ import play.api.data.Forms._
 
 object ConfirmCreateGroupForm {
 
-  val groupNameRegex = "^[!%*^()_+\\\\\\-={}:;@~#,.?\\[\\]\\\\/A-Za-z0-9 ]{0,}$"
+  val groupNameRegex = "^[!%*^()_+\\-={}:;@~#,.?\\[\\]/A-Za-z0-9 ]{0,}$"
 
   def form(errorMessageKey: String): Form[ConfirmGroup] = Form(
     mapping(

--- a/app/forms/GroupNameForm.scala
+++ b/app/forms/GroupNameForm.scala
@@ -21,7 +21,7 @@ import play.api.data.Forms._
 
 object GroupNameForm {
 
-  val groupNameRegex = "^[!%*^()_+\\\\\\-={}:;@~#,.?\\[\\]\\\\/A-Za-z0-9 ]{0,}$"
+  val groupNameRegex = "^[!%*^()_+\\-={}:;@~#,.?\\[\\]/A-Za-z0-9 ]{0,}$"
 
   def form(): Form[String] = {
     Form(

--- a/conf/messages
+++ b/conf/messages
@@ -219,7 +219,7 @@ update-client-reference.caption=Tax reference: {0}
 update-client-reference.text=Please note that adding a client reference here does not update the client’s details in the Government Gateway account. It only affects the client reference in your access groups.
 error.client-reference.required=Enter client reference
 error.client-reference.max-length=Client reference must be 80 characters or fewer
-error.client-reference.invalid=Client reference must only include letters a to z, numbers and these characters: ! % * ^ ( ) _ + - = '{' '}' : ; @ ~ # , . ? [ ]
+error.client-reference.invalid=Client reference must only include letters a to z, numbers, spaces and these characters: ! % * ^ ( ) _ + - = '{' '}' : ; @ ~ # , . ? [ ]
 
 client-reference.updated.title=Client reference updated
 client-reference.updated.panel=Client reference updated to {0}

--- a/conf/messages.cy
+++ b/conf/messages.cy
@@ -233,7 +233,7 @@ update-client-reference.text=Sylwer – nid yw ychwanegu cyfeirnod cleient yn y 
 error.client-reference.required=Nodwch y cyfeirnod cleient
 error.client-reference.max-length=Mae’n rhaid i’r cyfeirnod cleient fod yn 80 o gymeriadau neu lai
 #No welsh
-error.client-reference.invalid=Client reference must only include letters a to z, numbers and these characters: ! % * ^ ( ) _ + - = '{' '}' : ; @ ~ # , . ? [ ]
+error.client-reference.invalid=Client reference must only include letters a to z, numbers, spaces and these characters: ! % * ^ ( ) _ + - = '{' '}' : ; @ ~ # , . ? [ ]
 
 client-reference.updated.title=Cyfeirnod cleient wedi’i ddiweddaru
 client-reference.updated.panel=Cyfeirnod cleient wedi’i ddiweddaru i {0}

--- a/test/controllers/OptInControllerSpec.scala
+++ b/test/controllers/OptInControllerSpec.scala
@@ -21,10 +21,11 @@ import connectors.{AgentPermissionsConnector, AgentUserClientDetailsConnector}
 import helpers.{BaseSpec, Css}
 import org.jsoup.Jsoup
 import play.api.Application
+import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repository.SessionCacheRepository
-import uk.gov.hmrc.agentmtdidentifiers.model.{OptedInNotReady, OptedInReady, OptedOutEligible, OptinStatus, OptedOutSingleUser}
+import uk.gov.hmrc.agentmtdidentifiers.model.{OptedInNotReady, OptedInReady, OptedOutEligible, OptedOutSingleUser, OptinStatus}
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.syntax.retrieved.authSyntaxForRetrieved
 import uk.gov.hmrc.http.{SessionKeys, UpstreamErrorResponse}
@@ -182,7 +183,7 @@ class OptInControllerSpec extends BaseSpec {
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       expectIsArnAllowed(allowed = true)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", s"${routes.OptInController.submitDoYouWantToOptIn}")
           .withFormUrlEncodedBody("answer" -> "true")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -203,7 +204,7 @@ class OptInControllerSpec extends BaseSpec {
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       expectIsArnAllowed(allowed = true)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", s"${routes.OptInController.submitDoYouWantToOptIn}")
           .withFormUrlEncodedBody("answer" -> "false")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -222,7 +223,7 @@ class OptInControllerSpec extends BaseSpec {
       expectAuthorisationGrantsAccess(mockedAuthResponse)
       expectIsArnAllowed(allowed = true)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", s"${routes.OptInController.submitDoYouWantToOptIn}")
           .withFormUrlEncodedBody("answer" -> "")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -252,7 +253,7 @@ class OptInControllerSpec extends BaseSpec {
       expectIsArnAllowed(allowed = true)
       stubPostOptInError(arn)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", "/opt-in/do-you-want-to-opt-in")
           .withFormUrlEncodedBody("answer" -> "true")
           .withSession(SessionKeys.sessionId -> "session-x")

--- a/test/controllers/OptOutControllerSpec.scala
+++ b/test/controllers/OptOutControllerSpec.scala
@@ -21,6 +21,7 @@ import connectors.AgentPermissionsConnector
 import helpers.{BaseSpec, Css}
 import org.jsoup.Jsoup
 import play.api.Application
+import play.api.mvc.AnyContentAsFormUrlEncoded
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
 import repository.SessionCacheRepository
@@ -34,7 +35,7 @@ class OptOutControllerSpec extends BaseSpec {
   implicit lazy val mockAgentPermissionsConnector: AgentPermissionsConnector =
     mock[AgentPermissionsConnector]
 
-  override def moduleWithOverrides = new AbstractModule() {
+  override def moduleWithOverrides: AbstractModule = new AbstractModule() {
 
     override def configure(): Unit = {
       bind(classOf[AuthAction])
@@ -50,14 +51,14 @@ class OptOutControllerSpec extends BaseSpec {
       .configure("mongodb.uri" -> mongoUri)
       .build()
 
-  val controller = fakeApplication.injector.instanceOf[OptOutController]
+  val controller: OptOutController = fakeApplication.injector.instanceOf[OptOutController]
 
   s"GET ${routes.OptOutController.start}" should {
 
     "display content for start" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
+      expectIsArnAllowed(allowed = true)
 
       await(sessionCacheRepository.putSession(OPTIN_STATUS, OptedInSingleUser))
 
@@ -95,7 +96,7 @@ class OptOutControllerSpec extends BaseSpec {
     "display expected content" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
+      expectIsArnAllowed(allowed = true)
 
       await(sessionCacheRepository.putSession(OPTIN_STATUS, OptedInSingleUser))
 
@@ -129,10 +130,10 @@ class OptOutControllerSpec extends BaseSpec {
     s"redirect to ${routes.OptOutController.showYouHaveOptedOut} page with answer 'true'" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
+      expectIsArnAllowed(allowed = true)
       stubOptInStatusOk(arn)(OptedOutEligible)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", "/opt-out/do-you-want-to-opt-out")
           .withFormUrlEncodedBody("answer" -> "true")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -149,9 +150,9 @@ class OptOutControllerSpec extends BaseSpec {
     "redirect to 'manage dashboard' page when user decides not to opt out" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
+      expectIsArnAllowed(allowed = true)
 
-      implicit val request =
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", s"${routes.OptOutController.submitDoYouWantToOptOut}")
           .withFormUrlEncodedBody("answer" -> "false")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -168,8 +169,8 @@ class OptOutControllerSpec extends BaseSpec {
     "render correct error messages when form not filled in" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
-      implicit val request =
+      expectIsArnAllowed(allowed = true)
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
         FakeRequest("POST", s"${routes.OptOutController.submitDoYouWantToOptOut}")
           .withFormUrlEncodedBody("answer" -> "")
           .withSession(SessionKeys.sessionId -> "session-x")
@@ -198,7 +199,7 @@ class OptOutControllerSpec extends BaseSpec {
     "display expected content" in {
 
       expectAuthorisationGrantsAccess(mockedAuthResponse)
-      expectIsArnAllowed(true)
+      expectIsArnAllowed(allowed = true)
       await(sessionCacheRepository.putSession(OPTIN_STATUS, OptedOutEligible))
 
       val result = controller.showYouHaveOptedOut()(request)

--- a/test/forms/ClientReferenceFormSpec.scala
+++ b/test/forms/ClientReferenceFormSpec.scala
@@ -31,8 +31,8 @@ class ClientReferenceFormSpec
   "ClientReferenceForm binding" should {
 
     "be successful when non-empty" in {
-      val params = Map(clientReference -> "XYZ@42")
-      ClientReferenceForm.form().bind(params).value shouldBe Some("XYZ@42")
+      val params = Map(clientReference -> "XYZ @42")
+      ClientReferenceForm.form().bind(params).value shouldBe Some("XYZ @42")
     }
 
     "have errors when empty" in {
@@ -57,8 +57,8 @@ class ClientReferenceFormSpec
         .message shouldBe "error.client-reference.max-length"
     }
 
-    "have errors with spaces" in {
-      val params = Map(clientReference -> "123 invalid")
+    "have errors when invalid characters < present" in {
+      val params = Map(clientReference -> "<invalid>")
       val validatedForm = ClientReferenceForm.form().bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm.errors.length shouldBe 1
@@ -68,8 +68,8 @@ class ClientReferenceFormSpec
         .message shouldBe "error.client-reference.invalid"
     }
 
-    "have errors when it does not match regex" in {
-      val params = Map(clientReference -> "   <invalid>")
+    "have errors when invalid characters \\ present" in {
+      val params = Map(clientReference -> "inva\\id")
       val validatedForm = ClientReferenceForm.form().bind(params)
       validatedForm.hasErrors shouldBe true
       validatedForm.errors.length shouldBe 1
@@ -78,6 +78,7 @@ class ClientReferenceFormSpec
         .get
         .message shouldBe "error.client-reference.invalid"
     }
+
   }
 
 }

--- a/test/forms/ConfirmGroupNameFormSpec.scala
+++ b/test/forms/ConfirmGroupNameFormSpec.scala
@@ -57,8 +57,20 @@ class ConfirmGroupNameFormSpec
         .message shouldBe "group.name.max.length"
     }
 
-    "have errors when group name hidden input contains invalid characters" in {
+    "have errors when group name hidden input has invalid character < present" in {
       val params = Map(groupNameField -> "invalid < chars>  ",
+        answerField -> "true")
+      val validatedForm = ConfirmCreateGroupForm.form("").bind(params)
+      validatedForm.hasErrors shouldBe true
+      validatedForm.errors.length shouldBe 1
+      validatedForm
+        .error(groupNameField)
+        .get
+        .message shouldBe "group.name.invalid"
+    }
+
+    "have errors when group name hidden input has invalid character \\ present" in {
+      val params = Map(groupNameField -> "invalid \\chars",
         answerField -> "true")
       val validatedForm = ConfirmCreateGroupForm.form("").bind(params)
       validatedForm.hasErrors shouldBe true

--- a/test/forms/GroupNameFormSpec.scala
+++ b/test/forms/GroupNameFormSpec.scala
@@ -57,7 +57,7 @@ class GroupNameFormSpec
         .message shouldBe "group.name.max.length"
     }
 
-    "have errors when invalid characters" in {
+    "have errors when invalid characters < present" in {
       val params = Map(groupNameField -> " invalid <chars")
       val validatedForm = GroupNameForm.form().bind(params)
       validatedForm.hasErrors shouldBe true
@@ -67,6 +67,18 @@ class GroupNameFormSpec
         .get
         .message shouldBe "group.name.invalid"
     }
+
+    "have errors when invalid character \\ present" in {
+      val params = Map(groupNameField -> " invalid \\chars")
+      val validatedForm = GroupNameForm.form().bind(params)
+      validatedForm.hasErrors shouldBe true
+      validatedForm.errors.length shouldBe 1
+      validatedForm
+        .error(groupNameField)
+        .get
+        .message shouldBe "group.name.invalid"
+    }
+
   }
 
 }


### PR DESCRIPTION
- also allows spaces in client reference again

might want to rethink the error message to be must not include these special characters: < > \
but that's just content