### PR TITLE
APB-6472 [CS] bugfix for manage clients

### DIFF
--- a/app/controllers/ManageClientController.scala
+++ b/app/controllers/ManageClientController.scala
@@ -59,7 +59,7 @@ class ManageClientController @Inject()(
   def showAllClients: Action[AnyContent] = Action.async { implicit request =>
     isAuthorisedAgent { arn =>
       isOptedIn(arn) { _ =>
-        clientService.getClients(arn).flatMap { maybeClients =>
+        clientService.getAllClients(arn).flatMap { maybeClients =>
           val searchFilter: SearchFilter = SearchAndFilterForm.form().bindFromRequest().get
           searchFilter.submit.fold(
             //no filter/clear was applied

--- a/app/controllers/UnassignedClientController.scala
+++ b/app/controllers/UnassignedClientController.scala
@@ -110,7 +110,6 @@ class UnassignedClientController @Inject()(
                   } yield result
                 },
                 formData => {
-                  // TODO update the filter here, currently filters from a list of ALL clients rather than just unassigned clients
                   clientService.saveSelectedOrFilteredClients(buttonSelection)(arn)(formData)(clientService.getUnassignedClients).map(_ =>
                     if(buttonSelection == ButtonSelect.Continue)
                       Redirect(controller.showSelectedUnassignedClients)

--- a/test/services/ClientServiceSpec.scala
+++ b/test/services/ClientServiceSpec.scala
@@ -105,7 +105,5 @@ class ClientServiceSpec extends BaseSpec {
   }
 
   // TODO implement tests for addClient/addTeamMember, refactor processFormData?
-  "filterClients" should {}
-
 
 }


### PR DESCRIPTION
Updated so manage clients always starts with full es3 list

`FILTERED_CLIENTS` in session could be
- filtered unassigned clients (unassigned client list, applied filter)
- manage group clients list (full client list, then applied filter)
- create group client list (full client list, then applied filter)

At the moment, I think filtered clients will be 'remembered' between these three journeys? But in these cases the 'Clear filters' button will actually work so it's not as big an issue