### PR TITLE
APB-6979 [CS] revert search client options

### DIFF
--- a/app/controllers/CreateGroupSelectClientsController.scala
+++ b/app/controllers/CreateGroupSelectClientsController.scala
@@ -63,16 +63,13 @@ class CreateGroupSelectClientsController @Inject()
     withGroupNameAndAuthorised { (groupName, _, arn) =>
       withSessionItem[String](CLIENT_FILTER_INPUT) { clientFilterTerm =>
         withSessionItem[String](CLIENT_SEARCH_INPUT) { clientSearchTerm =>
-          clientService.getAvailableTaxServiceClientCount(arn).map(clientCounts =>
             Ok(
               search_clients(
                 form = SearchAndFilterForm.form().fill(SearchFilter(clientSearchTerm, clientFilterTerm, None)),
                 groupName = groupName,
-                backUrl = Some(controllers.routes.CreateGroupSelectNameController.showConfirmGroupName.url),
-                clientCountByTaxService = clientCounts
+                backUrl = Some(controllers.routes.CreateGroupSelectNameController.showConfirmGroupName.url)
               )
-            )
-          )
+          ).toFuture
         }
       }
     }
@@ -85,16 +82,13 @@ class CreateGroupSelectClientsController @Inject()
         .bindFromRequest
         .fold(
           formWithErrors => {
-            clientService.getAvailableTaxServiceClientCount(arn).map(clientCounts =>
               Ok(
                 search_clients(
                   formWithErrors,
                   groupName,
-                  Some(controllers.routes.CreateGroupSelectNameController.showConfirmGroupName.url),
-                  clientCountByTaxService = clientCounts
+                  Some(controllers.routes.CreateGroupSelectNameController.showConfirmGroupName.url)
                 ),
-              )
-            )
+              ).toFuture
           }, formData => {
             sessionCacheOps.saveSearch(formData.search, formData.filter).flatMap(_ => {
               Redirect(controller.showSelectClients(Some(1), Some(20))).toFuture

--- a/app/controllers/ManageGroupClientsController.scala
+++ b/app/controllers/ManageGroupClientsController.scala
@@ -111,17 +111,14 @@ class ManageGroupClientsController @Inject()
     withGroupSummaryForAuthorisedOptedAgent(groupId) { (summary: GroupSummary, arn: Arn) =>
       withSessionItem[String](CLIENT_FILTER_INPUT) { clientFilterTerm =>
         withSessionItem[String](CLIENT_SEARCH_INPUT) { clientSearchTerm =>
-          clientService.getAvailableTaxServiceClientCount(arn).map(clientCounts =>
             Ok(
               search_clients(
                 form = SearchAndFilterForm.form().fill(SearchFilter(clientSearchTerm, clientFilterTerm, None)),
                 groupName = summary.groupName,
                 backUrl = Some(controller.showExistingGroupClients(groupId, None, None).url),
-                formAction = controller.submitSearchClientsToAdd(groupId),
-                clientCountByTaxService = clientCounts
+                formAction = controller.submitSearchClientsToAdd(groupId)
               )
-            )
-          )
+            ).toFuture
         }
       }
     }
@@ -134,17 +131,14 @@ class ManageGroupClientsController @Inject()
         .bindFromRequest
         .fold(
           formWithErrors => {
-            clientService.getAvailableTaxServiceClientCount(arn).map(clientCounts =>
               Ok(
                 search_clients(
                   formWithErrors,
                   summary.groupName,
                   backUrl = Some(controller.showExistingGroupClients(groupId, None, None).url),
-                  formAction = controller.submitSearchClientsToAdd(groupId),
-                  clientCountByTaxService = clientCounts
+                  formAction = controller.submitSearchClientsToAdd(groupId)
                 )
-              )
-            )
+              ).toFuture
           }, formData => {
             sessionCacheOps.saveSearch(formData.search, formData.filter).flatMap(_ => {
               Redirect(controller.showManageGroupClients(groupId, None, None)).toFuture

--- a/app/views/groups/create/clients/search_clients.scala.html
+++ b/app/views/groups/create/clients/search_clients.scala.html
@@ -35,8 +35,7 @@
     form: Form[SearchFilter],
     groupName: String,
     backUrl: Option[String] = Some(routes.CreateGroupSelectNameController.showConfirmGroupName.url),
-    formAction: Call = routes.CreateGroupSelectClientsController.submitSearchClients,
-    clientCountByTaxService: Map[String, Int]
+    formAction: Call = routes.CreateGroupSelectClientsController.submitSearchClients
 )(implicit request: Request[_], msgs: Messages, appConfig: AppConfig)
 
 @fieldsetHtml = {
@@ -51,7 +50,7 @@
         field = form("filter"),
         label = msgs("client-filter.select.label"),
         emptyOptionText = msgs("client-filter.select.label.empty-option"),
-        options = getFiltersTaxServiceListWithClientCount(clientCountByTaxService)
+        options = getFiltersByTaxService()
     )
 }
 

--- a/test/controllers/CreateGroupSelectClientsControllerSpec.scala
+++ b/test/controllers/CreateGroupSelectClientsControllerSpec.scala
@@ -86,7 +86,6 @@ class CreateGroupSelectClientsControllerSpec extends BaseSpec {
       expectAuthOkArnAllowedOptedInReadyWithGroupName()
       expectGetSessionItemNone(CLIENT_SEARCH_INPUT)
       expectGetSessionItemNone(CLIENT_FILTER_INPUT)
-      expectGetAvailableTaxServiceClientCount(arn)(List(13, 85, 38, 22, 108))
 
       val result = controller.showSearchClients()(request)
       // then
@@ -110,7 +109,6 @@ class CreateGroupSelectClientsControllerSpec extends BaseSpec {
       expectAuthOkArnAllowedOptedInReadyWithGroupName()
       expectGetSessionItem(CLIENT_SEARCH_INPUT, "Harry")
       expectGetSessionItem(CLIENT_FILTER_INPUT, "HMRC-MTD-VAT")
-      expectGetAvailableTaxServiceClientCount(arn)(List(13, 85, 38, 22, 108))
 
       val result = controller.showSearchClients()(request)
       // then

--- a/test/controllers/ManageGroupClientsControllerSpec.scala
+++ b/test/controllers/ManageGroupClientsControllerSpec.scala
@@ -298,7 +298,6 @@ class ManageGroupClientsControllerSpec extends BaseSpec {
       val summary = GroupSummary.fromAccessGroup(accessGroup)
       expectAuthOkOptedInReady()
       expectGetCustomSummaryById(grpId, Some(summary))
-      expectGetAvailableTaxServiceClientCount(arn)(List(13, 85, 38, 22, 108))
 
       expectGetSessionItemNone(CLIENT_SEARCH_INPUT)
       expectGetSessionItemNone(CLIENT_FILTER_INPUT)
@@ -327,7 +326,6 @@ class ManageGroupClientsControllerSpec extends BaseSpec {
       expectGetCustomSummaryById(grpId, Some(summary))
       expectGetSessionItem(CLIENT_SEARCH_INPUT, "Harry")
       expectGetSessionItem(CLIENT_FILTER_INPUT, "HMRC-MTD-VAT")
-      expectGetAvailableTaxServiceClientCount(arn)(List(13, 85, 38, 22, 108))
 
       val result = controller.showSearchClientsToAdd(grpId)(request)
       // then


### PR DESCRIPTION
`getAvailableTaxServiceClientCount` will hide a tax service if a tax service group of that type has been created - but an agent might still want to add clients from that tax service to a custom group.

A different implementation will be required to hide tax services an agent has no clients for - if we still wanted to do that. I don't really see an issue with the "No clients found" they'd see, which is the same as any other search that had no results.