### PR TITLE
APB-7056 [CS] clear manage session keys

### DIFF
--- a/app/controllers/ManageGroupController.scala
+++ b/app/controllers/ManageGroupController.scala
@@ -68,6 +68,7 @@ class ManageGroupController @Inject()
   def showManageGroups(page: Option[Int] = None, pageSize: Option[Int] = None): Action[AnyContent] = Action.async { implicit request =>
     isAuthorisedAgent { arn =>
       isOptedIn(arn) { _ =>
+        sessionCacheService.deleteAll(managingGroupKeys).flatMap(_ =>
         sessionCacheService.get(GROUP_SEARCH_INPUT)
           .flatMap(maybeSearchTerm => {
             groupService
@@ -81,6 +82,7 @@ class ManageGroupController @Inject()
               }
           }
           )
+        )
       }
     }
   }

--- a/app/controllers/package.scala
+++ b/app/controllers/package.scala
@@ -123,6 +123,15 @@ package object controllers {
       RETURN_URL,
     )
 
+  val managingGroupKeys = (
+      clientFilteringKeys ++
+      teamMemberFilteringKeys ++
+      List(
+        SELECTED_CLIENTS,
+        SELECTED_TEAM_MEMBERS
+      )
+    ).distinct
+
   val sessionKeys = (
     clientFilteringKeys ++
       teamMemberFilteringKeys ++

--- a/test/controllers/ManageGroupControllerSpec.scala
+++ b/test/controllers/ManageGroupControllerSpec.scala
@@ -114,9 +114,12 @@ class ManageGroupControllerSpec extends BaseSpec {
 
       //given
       expectAuthOkOptedInReady()
+      expectDeleteSessionItems(managingGroupKeys)
+
       val searchTerm = "ab"
       val groupSummaries = (1 to 3).map(i => GroupSummary(s"groupId$i", s"name $i", Some(i * 3), i * 4))
       expectGetPaginatedGroupSummaries(arn, searchTerm)(1, 5)(groupSummaries)
+
       expectGetSessionItem(GROUP_SEARCH_INPUT, searchTerm)
 
       //when
@@ -169,8 +172,11 @@ class ManageGroupControllerSpec extends BaseSpec {
 
       //given
       expectAuthOkOptedInReady()
+      expectDeleteSessionItems(managingGroupKeys)
+
       val searchTerm = "ab"
       expectGetPaginatedGroupSummaries(arn, searchTerm)(1, 5)(Nil)
+
       expectGetSessionItem(GROUP_SEARCH_INPUT, searchTerm)
 
       //when
@@ -202,6 +208,7 @@ class ManageGroupControllerSpec extends BaseSpec {
     "render content when filtered access groups" in {
       //given
       expectAuthOkOptedInReady()
+      expectDeleteSessionItems(managingGroupKeys)
 
       val expectedGroupSummaries = (1 to 3).map(i => GroupSummary(s"groupId$i", s"GroupName$i", Some(i * 3), i * 4))
       val searchTerm = expectedGroupSummaries(0).groupName


### PR DESCRIPTION
Clears the following keys from the session on the show manage groups page
SELECTED_CLIENTS,
SELECTED_TEAM_MEMBERS,
CLIENT_FILTER_INPUT,
CLIENT_SEARCH_INPUT
TEAM_MEMBER_SEARCH_INPUT

So if a transaction starts (managing clients/team members) but does not complete, and the user goes back and tries to do something with another group the data is cleared, so it can be reset properly when starting with the new group

Search & filter won't be remembered if they click into the same group again