### PR TITLE
APB-7231a [CS] DisplayClient model hack

### DIFF
--- a/app/controllers/ManageTaxGroupClientsController.scala
+++ b/app/controllers/ManageTaxGroupClientsController.scala
@@ -281,7 +281,7 @@ class ManageTaxGroupClientsController @Inject()
   private def updateExcludedClients(groupId: GroupId, maybeSelected: Option[Seq[DisplayClient]], currentPageClients: Option[Seq[DisplayClient]], formData: AddClientsToGroup, excludedClients: Set[Client])
                                    (implicit request: Request[_], hc: HeaderCarrier): Future[Int] = {
     val clientsToUnexclude = clientsSelectedIncludingCurrentPage(maybeSelected, currentPageClients, formData)
-    val clients: Set[Client] = excludedClients -- clientsToUnexclude.map(toClient(_))
+    val clients: Set[Client] = excludedClients -- clientsToUnexclude.map(toClient)
     val updateRequest = UpdateTaxServiceGroupRequest(excludedClients = Option(clients))
     for {
       _ <- taxGroupService.updateGroup(groupId, updateRequest)
@@ -304,7 +304,7 @@ class ManageTaxGroupClientsController @Inject()
         sortedExcludedClients
           .filter(dc => dc.name.toLowerCase.contains(lowerCaseSearch) || dc.hmrcRef.toLowerCase.contains(lowerCaseSearch))
     }
-    if (!maybeSelected.getOrElse(Seq.empty[DisplayClient]).isEmpty) {
+    if (maybeSelected.getOrElse(Seq.empty[DisplayClient]).nonEmpty) {
       sortedExcludedClients = sortedExcludedClients.map(dc => dc.copy(selected = maybeSelected.get.map(_.id).contains(dc.id)))
     }
     val pagination = PaginatedListBuilder.build(pge, pgSize, sortedExcludedClients)

--- a/app/models/Selectable.scala
+++ b/app/models/Selectable.scala
@@ -71,7 +71,7 @@ case object DisplayClient {
 
   implicit val format: OFormat[DisplayClient] = Json.format[DisplayClient]
 
-  //TODO problematic?
+  //TODO problematic assumption about where the 'key' identifier (hmrcRef) is in an enrolmentKey
   def fromClient(client: Client, selected: Boolean = false): DisplayClient = {
     val keyElements = client.enrolmentKey.split('~')
     val taxService = keyElements.head
@@ -88,6 +88,6 @@ case object DisplayClient {
       selected)
   }
 
-  //TODO problematic
+  //TODO problematic assumption about where the 'key' identifier (hmrcRef) is in an enrolmentKey
   def toClient(dc: DisplayClient): Client = Client(s"${dc.taxService}~${dc.enrolmentKeyMiddle}~${dc.hmrcRef}", dc.name)
 }

--- a/test/models/SelectableSpec.scala
+++ b/test/models/SelectableSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import uk.gov.hmrc.agents.accessgroups.Client
+
+class SelectableSpec extends AnyWordSpec with Matchers {
+
+  "DisplayClient" should {
+    "be converted from Client" when {
+      "client is cbc uk" in {
+        val cbcUkClient = Client("HMRC-CBC-ORG~UTR~1234567890~cbcId~XACBC123456789012", "Jelly Incorporated")
+
+        //when
+        val dc = DisplayClient.fromClient(cbcUkClient)
+
+        val expectedDc = DisplayClient(
+          "XACBC123456789012",
+          "Jelly Incorporated",
+          "HMRC-CBC-ORG",
+          "UTR~1234567890~cbcId")
+
+        //then
+        dc shouldBe expectedDc
+      }
+
+      "client has no friendly name" in {
+        val vatClient =  Client("HMRC-MTD-VAT~VRN~123456789", "")
+
+        //when
+        val dc = DisplayClient.fromClient(vatClient)
+
+        val expectedDc = DisplayClient(
+          "123456789",
+          "",
+          "HMRC-MTD-VAT",
+          "VRN")
+
+        //then
+        dc shouldBe expectedDc
+      }
+
+    }
+
+    "convert back to Client model" when {
+      "client is cbc uk" in {
+        val cbcUkDisplayClient = DisplayClient(
+          "XACBC123456789012",
+          "Jelly Incorporated",
+          "HMRC-CBC-ORG",
+          "UTR~1234567890~cbcId")
+
+        //when
+        val client = DisplayClient.toClient(cbcUkDisplayClient)
+
+        val expectedCbcUkClient = Client("HMRC-CBC-ORG~UTR~1234567890~cbcId~XACBC123456789012", "Jelly Incorporated")
+
+        //then
+        client shouldBe expectedCbcUkClient
+      }
+
+      "client has no friendly name" in {
+        val vatDc = DisplayClient(
+          "123456789",
+          "",
+          "HMRC-MTD-VAT",
+          "VRN")
+
+        //when
+        val client = DisplayClient.toClient(vatDc)
+
+        val expectedVatClient =  Client("HMRC-MTD-VAT~VRN~123456789", "")
+
+        //then
+        client shouldBe expectedVatClient
+      }
+
+    }
+  }
+
+}


### PR DESCRIPTION
should work for cbc uk, but in general might need to re-think about extracting the "key identifier" for any given service and keeping the rest of the enrolment key info or somehow retrieving it at the point of creating/updating a group