### PR TITLE
APB-7427 [CS] Bug fix for manage group clients

### DIFF
--- a/app/controllers/UnassignedClientController.scala
+++ b/app/controllers/UnassignedClientController.scala
@@ -230,9 +230,9 @@ class UnassignedClientController @Inject()(
                         formWithErrors
                       )
                     ).toFuture
-                  }, (yes: Boolean) => {
-                    sessionCacheService.put(CONFIRM_CLIENTS_SELECTED, yes).map(_ =>
-                      if (yes) {
+                  }, (selectMoreClients: Boolean) => {
+                    sessionCacheService.put(CONFIRM_CLIENTS_SELECTED, selectMoreClients).map(_ =>
+                      if (selectMoreClients) {
                         Redirect(controller.showUnassignedClients())
                       } else {
                         Redirect(controller.showSelectGroupsForSelectedUnassignedClients())

--- a/test/controllers/ManageGroupClientsControllerSpec.scala
+++ b/test/controllers/ManageGroupClientsControllerSpec.scala
@@ -537,10 +537,8 @@ class ManageGroupClientsControllerSpec extends BaseSpec {
           submit = CONTINUE_BUTTON
         )
         expectSaveClientsToAddToExistingGroup(formData, displayClients)
-        //        expectGetPaginatedClientsToAddToGroup(grpId)(groupSummary, existingClients ++ availableClients)
         expectGetSessionItem(CLIENT_SEARCH_INPUT, "Harry")
         expectGetSessionItem(CLIENT_FILTER_INPUT, "HMRC-MTD-VAT")
-        expectDeleteSessionItems(clientFilteringKeys)
 
         //when
         val result = controller.submitAddClients(grpId)(request)
@@ -774,6 +772,7 @@ class ManageGroupClientsControllerSpec extends BaseSpec {
       expectAuthOkOptedInReady()
       expectGetSessionItem(SELECTED_CLIENTS, displayClients)
       expectGetCustomSummaryById(grpId, Some(GroupSummary.of(accessGroup)))
+      expectDeleteSessionItems(clientFilteringKeys)
 
       val result = controller.submitReviewSelectedClients(grpId)(request)
 


### PR DESCRIPTION
Don't clear filters before arriving on review selected clients page [submitAddClients] 
instead, clear if selecting more clients (radio option, back to search) [submitReviewSelectedClients]
so if the user clicks the back link, the filters will be the same as they left it - but if they want to select more clients the search/filter is cleared so they can enter new terms