### PR TITLE
APB-7382b [CS] fix Multiple issues with "Which custom access groups would you like to add the selected clients to?" page

### DIFF
--- a/app/controllers/AddClientToGroupsController.scala
+++ b/app/controllers/AddClientToGroupsController.scala
@@ -84,16 +84,20 @@ class AddClientToGroupsController @Inject()(
             )
           }
         }
-      }, { groupIdsStr =>
-        val groupIds: Seq[GroupId] = groupIdsStr.map(GroupId.fromString)
-        val client = Client(displayClient.enrolmentKey, displayClient.name)
-        Future.sequence(groupIds.map { grp =>
-          groupService.addMembersToGroup(
-            grp, AddMembersToAccessGroupRequest(clients = Some(Set(client))
-            ))
-        }).map { _ =>
-          sessionCacheService.put[Seq[GroupId]](GROUP_IDS_ADDED_TO, groupIds)
-          Redirect(routes.AddClientToGroupsController.showConfirmClientAddedToGroups(clientId))
+      }, { validForm =>
+        if (validForm.contains(AddGroupsToClientForm.NoneValue)) {
+          Redirect(appConfig.agentServicesAccountManageAccountUrl).toFuture
+        } else {
+          val groupIds: Seq[GroupId] = validForm.map(GroupId.fromString)
+          val client = Client(displayClient.enrolmentKey, displayClient.name)
+          Future.sequence(groupIds.map { grp =>
+            groupService.addMembersToGroup(
+              grp, AddMembersToAccessGroupRequest(clients = Some(Set(client))
+              ))
+          }).map { _ =>
+            sessionCacheService.put[Seq[GroupId]](GROUP_IDS_ADDED_TO, groupIds)
+            Redirect(routes.AddClientToGroupsController.showConfirmClientAddedToGroups(clientId))
+          }
         }
       }
       )

--- a/app/forms/AddGroupsToClientForm.scala
+++ b/app/forms/AddGroupsToClientForm.scala
@@ -19,12 +19,24 @@ package forms
 import play.api.data.Form
 import play.api.data.Forms._
 
+// TODO rename? also used for team members
 object AddGroupsToClientForm {
+  val NoneValue: String = "__none__"
+  /* A valid form will contain ONE of the following:
+    - a list of groups excluding the special 'none' value OR
+    - a list of groups containing ONLY the special 'none' value
+   */
 
   def form(): Form[List[String]] = {
     Form(
       single(
-        "groups" -> list(text).verifying("error.select.groups.empty", groups => groups.nonEmpty)
+        "groups" -> list(text)
+          // empty error
+          .verifying("error.select.groups.empty",
+            groups => groups.nonEmpty)
+          // Selected 'none of the above' AND one or more groups (can happen with JS disabled)
+          .verifying("unassigned.client.assign.invalid-selection.error",
+            groups => if(groups.contains(NoneValue)) groups.length == 1 else groups.length > 1)
       )
     )
   }

--- a/app/views/components/checkboxes.scala.html
+++ b/app/views/components/checkboxes.scala.html
@@ -27,7 +27,7 @@
     name: String,
     items: Seq[CheckboxData],
     hint: Option[String] = None,
-    legend: Option[LegendData] = None
+    legend: Option[LegendData]
 )(implicit msgs: Messages)
 
     @govukCheckboxes(

--- a/app/views/group_member_details/add_groups_to_client/select_groups.scala.html
+++ b/app/views/group_member_details/add_groups_to_client/select_groups.scala.html
@@ -17,6 +17,7 @@
 @import config.AppConfig
 @import controllers.routes
 @import uk.gov.hmrc.agents.accessgroups.GroupSummary
+@import forms.AddGroupsToClientForm
 @import views.components.models.{CheckboxData, LegendData}
 @import views.html.main_layout
 
@@ -52,11 +53,11 @@
 
     @if(form.errors && availableGroups.nonEmpty) {
         @govukErrorSummary(
-            ErrorSummary(errorList = Seq(
-                ErrorLink(Some("#" + availableGroups(0).groupId),
-                    Text(msgs("error.select.groups.empty"))
-                )
-            )
+            ErrorSummary(
+                errorList = Seq(
+                    ErrorLink(Some("#" + availableGroups(0).groupId), Text(msgs("error.select.groups.empty")))
+                ),
+                title = Text(msgs("common.errorSummary.heading"))
             )
         )
     }
@@ -76,7 +77,6 @@
     @if(!availableGroups.isEmpty) {
 
         @formWithCSRF(action = routes.AddClientToGroupsController.submitSelectGroupsForClient(client.id)) {
-            <fieldset class="govuk-fieldset">
                 @checkboxes(
                     id = Some("groups"),
                     hint = Some(msgs("client.select.groups.hint")),
@@ -88,7 +88,15 @@
                             label = g.groupName,
                             value = g.groupId.toString
                         )
-                    },
+                    } :+ CheckboxData( /* none of the above */
+                        id = AddGroupsToClientForm.NoneValue,
+                        name = "groups[]",
+                        label = msgs("unassigned.client.assign.none-of-the-above"),
+                        hint = Some(msgs("unassigned.client.assign.none-of-the-above.hint")),
+                        value = AddGroupsToClientForm.NoneValue,
+                        checked = form.data.exists { case (k, v) => k.contains("groups") && v == AddGroupsToClientForm.NoneValue },
+                        exclusive = true
+                    ),
                     legend = Some(LegendData(h1Text, classes = Some("govuk-visually-hidden")))
                 )
 
@@ -98,7 +106,6 @@
                     classes = Some("govuk-button--secondary govuk-!-margin-right-3")
                 )
                 @submit_button(messageKey = "save.and.continue.button")
-            </fieldset>
         }
     } else {
         <div class="govuk-!-margin-top-8">

--- a/app/views/group_member_details/add_groups_to_team_member/select_groups.scala.html
+++ b/app/views/group_member_details/add_groups_to_team_member/select_groups.scala.html
@@ -16,9 +16,9 @@
 
 @import config.AppConfig
 @import controllers.routes
-@import views.components.models.CheckboxData
+@import forms.AddGroupsToClientForm
+@import views.components.models.{CheckboxData, LegendData}
 @import views.html.main_layout
-@import views.components.models.LegendData
 @import uk.gov.hmrc.agents.accessgroups.GroupSummary
 
 @this(
@@ -48,11 +48,11 @@
 
     @if(form.errors && availableGroups.nonEmpty) {
         @govukErrorSummary(
-            ErrorSummary(errorList = Seq(
-                ErrorLink(Some("#" + availableGroups(0).groupId),
-                    Text(msgs("error.select.groups.empty"))
-                )
-            )
+            ErrorSummary(
+                errorList = Seq(
+                    ErrorLink(Some("#" + availableGroups(0).groupId), Text(msgs("error.select.groups.empty")))
+                ),
+                title = Text(msgs("common.errorSummary.heading"))
             )
         )
     }
@@ -74,7 +74,6 @@
         @if(!availableGroups.isEmpty) {
 
             @formWithCSRF(action = routes.AddTeamMemberToGroupsController.submitSelectGroupsForTeamMember(teamMember.id)) {
-                <fieldset class="govuk-fieldset">
                     @checkboxes(
                         id = Some("groups"),
                         hint = Some(msgs("unassigned.client.assign.hint")),
@@ -86,7 +85,15 @@
                                 label = g.groupName,
                                 value = s"${g.groupType}_${g.groupId}"
                             )
-                        },
+                        } :+ CheckboxData( /* none of the above */
+                            id = AddGroupsToClientForm.NoneValue,
+                            name = "groups[]",
+                            label = msgs("unassigned.client.assign.none-of-the-above"),
+                            hint = Some(msgs("unassigned.client.assign.none-of-the-above.hint")),
+                            value = AddGroupsToClientForm.NoneValue,
+                            checked = form.data.exists { case (k, v) => k.contains("groups") && v == AddGroupsToClientForm.NoneValue },
+                            exclusive = true
+                        ),
                         legend = Some(LegendData(h1Text, classes = Some("govuk-visually-hidden")))
                     )
 
@@ -96,7 +103,6 @@
                         classes = Some("govuk-button--secondary govuk-!-margin-right-3")
                     )
                     @submit_button(messageKey = "save.and.continue.button")
-                </fieldset>
             }
         } else {
             <div class="govuk-!-margin-top-8">

--- a/app/views/unassigned_clients/select_groups_for_clients.scala.html
+++ b/app/views/unassigned_clients/select_groups_for_clients.scala.html
@@ -18,7 +18,7 @@
 @import controllers.routes
 @import forms.SelectGroups
 @import uk.gov.hmrc.agents.accessgroups.GroupSummary
-@import views.components.models.CheckboxData
+@import views.components.models.{CheckboxData, LegendData}
 @import views.html.main_layout
 @import forms.SelectGroupsForm
 
@@ -41,7 +41,7 @@
 @formErrorsClasses = @{if(form.errors) "govuk-form-group--error" else ""}
 
 @layout(
-title = msgs(heading),
+title = withErrorPrefix(form.hasErrors, msgs(heading)),
 backLink = Some(BackLink.mimicsBrowserBackButtonViaJavaScript(msgs))
 ) {
 
@@ -50,7 +50,8 @@ backLink = Some(BackLink.mimicsBrowserBackButtonViaJavaScript(msgs))
             ErrorSummary(
                 errorList = Seq(
                     ErrorLink(Some("#" + groups(0).groupId), Text(msgs(form.errors(0).message)))
-                )
+                ),
+                title = Text(msgs("common.errorSummary.heading"))
             )
         )
     }
@@ -73,9 +74,6 @@ backLink = Some(BackLink.mimicsBrowserBackButtonViaJavaScript(msgs))
                     )
             </div>
         } else {
-            <fieldset class="govuk-fieldset">
-                <legend class="govuk-visually-hidden">@heading</legend>
-
                 <div id="field-wrapper" class="govuk-form-group  @formErrorsClasses">
                     @if(form.errors) {
                         @p(key = form.errors(0).message,
@@ -105,13 +103,13 @@ backLink = Some(BackLink.mimicsBrowserBackButtonViaJavaScript(msgs))
                             checked = form.data.exists { case (k, v) => k.contains("groups") && v == SelectGroupsForm.NoneValue },
                             exclusive = true
                         ),
+                        legend = Some(LegendData(heading, classes = Some("govuk-visually-hidden"))),
                         hint = Some(msgs("unassigned.client.assign.hint"))
                     )
                 </div>
 
                 @submit_button("save.and.continue.button")
 
-            </fieldset>
         }
     }
 }

--- a/test/controllers/AddClientToGroupsControllerSpec.scala
+++ b/test/controllers/AddClientToGroupsControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import com.google.inject.AbstractModule
 import connectors.{AddMembersToAccessGroupRequest, AgentClientAuthorisationConnector, AgentPermissionsConnector, AgentUserClientDetailsConnector}
 import controllers.actions.AuthAction
+import forms.AddGroupsToClientForm
 import helpers.{BaseSpec, Css}
 import models.{DisplayClient, GroupId}
 import org.jsoup.Jsoup
@@ -219,6 +220,24 @@ class AddClientToGroupsControllerSpec extends BaseSpec {
           .shouldBe(routes.AddClientToGroupsController.showConfirmClientAddedToGroups(client.id).url)
 
       }
+    }
+
+    "redirect to manage account if 'none of the above' is selected" in {
+      //given
+      AuthOkWithClient()
+
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+        FakeRequest("POST", submitUrl)
+          .withFormUrlEncodedBody(
+            "groups[0]" -> s"${AddGroupsToClientForm.NoneValue}",
+            "submit" -> CONTINUE_BUTTON
+          )
+          .withSession(SessionKeys.sessionId -> "session-x")
+
+      val result = controller.submitSelectGroupsForClient(client.id)(request)
+
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result).get shouldBe controller.appConfig.agentServicesAccountManageAccountUrl
     }
 
     "display error when no groups are selected" in {

--- a/test/controllers/AddClientToGroupsControllerSpec.scala
+++ b/test/controllers/AddClientToGroupsControllerSpec.scala
@@ -100,16 +100,17 @@ class AddClientToGroupsControllerSpec extends BaseSpec {
       val form = html.select(Css.form)
       form.attr("action").shouldBe(submitUrl)
 
-      val fieldset = form.select("fieldset.govuk-fieldset")
-      fieldset.isEmpty shouldBe false // <-- fieldset needed for a11y
-
-      html.select("#groups-hint").text() shouldBe "You can only add clients to custom groups manually. Select all that apply."
+      val fieldset = form.select("fieldset.govuk-fieldset") // fieldset must exist and have a legend
+      fieldset.select(Css.legend).text() shouldBe "Which custom access groups would you like to add Client 0 to?"
+      fieldset.select("#groups-hint").text() shouldBe "You can only add clients to custom groups manually. Select all that apply."
       val checkboxes = fieldset.select(".govuk-checkboxes#groups input[name=groups[]]")
-      checkboxes.size() shouldBe 3
+      checkboxes.size() shouldBe 4
       val checkboxLabels = form.select("label.govuk-checkboxes__label")
       checkboxLabels.get(0).text() shouldBe "Group 3"
       checkboxLabels.get(1).text() shouldBe "Group 4"
       checkboxLabels.get(2).text() shouldBe "Group 5"
+      checkboxLabels.get(3).text() shouldBe "No access groups"
+      form.select("#__none__-item-hint").get(0).text() shouldBe "This will return you to the Manage account page"
       html.select(Css.linkStyledAsButton).text() shouldBe "Cancel"
       html.select(Css.linkStyledAsButton).hasClass("govuk-button--secondary")
       html.select(Css.linkStyledAsButton).hasClass("govuk-!-margin-right-3")
@@ -137,12 +138,18 @@ class AddClientToGroupsControllerSpec extends BaseSpec {
       html.select(Css.li("already-in-groups")).isEmpty shouldBe true
       val form = html.select(Css.form)
       form.attr("action").shouldBe(submitUrl)
-      val checkboxes = form.select(".govuk-checkboxes#groups input[name=groups[]]")
-      checkboxes.size() shouldBe 5
+
+      val fieldset = form.select("fieldset.govuk-fieldset") // fieldset must exist and have a legend
+      fieldset.size() shouldBe 1
+      fieldset.select(Css.legend).text() shouldBe "Which custom access groups would you like to add Client 0 to?"
+      val checkboxes = fieldset.select(".govuk-checkboxes#groups input[name=groups[]]")
+      checkboxes.size() shouldBe 6
       val checkboxLabels = form.select("label.govuk-checkboxes__label")
       checkboxLabels.get(0).text() shouldBe "Group 1"
       checkboxLabels.get(1).text() shouldBe "Group 2"
       checkboxLabels.get(2).text() shouldBe "Group 3"
+      checkboxLabels.get(5).text() shouldBe "No access groups"
+      form.select("#__none__-item-hint").get(0).text() shouldBe "This will return you to the Manage account page"
       html.select(Css.linkStyledAsButton).text() shouldBe "Cancel"
       html.select(Css.linkStyledAsButton).hasClass("govuk-button--secondary")
       html.select(Css.linkStyledAsButton).hasClass("govuk-!-margin-right-3")

--- a/test/controllers/AddTeamMemberToGroupsControllerSpec.scala
+++ b/test/controllers/AddTeamMemberToGroupsControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers
 import com.google.inject.AbstractModule
 import connectors.{AddOneTeamMemberToGroupRequest, AgentClientAuthorisationConnector, AgentPermissionsConnector}
 import controllers.actions.AuthAction
+import forms.AddGroupsToClientForm
 import helpers.{BaseSpec, Css}
 import models.{GroupId, TeamMember}
 import org.jsoup.Jsoup
@@ -229,6 +230,24 @@ class AddTeamMemberToGroupsControllerSpec extends BaseSpec {
           .shouldBe(ctrlRoute.showConfirmTeamMemberAddedToGroups(teamMember.id).url)
 
       }
+    }
+
+    "redirect to manage account if 'none of the above' is selected" in {
+      //given
+      AuthOkWithTeamMember()
+
+      implicit val request: FakeRequest[AnyContentAsFormUrlEncoded] =
+        FakeRequest("POST", submitUrl)
+          .withFormUrlEncodedBody(
+            "groups[0]" -> s"${AddGroupsToClientForm.NoneValue}",
+            "submit" -> CONTINUE_BUTTON
+          )
+          .withSession(SessionKeys.sessionId -> "session-x")
+
+      val result = controller.submitSelectGroupsForTeamMember(teamMember.id)(request)
+
+      status(result) shouldBe SEE_OTHER
+      redirectLocation(result).get shouldBe controller.appConfig.agentServicesAccountManageAccountUrl
     }
 
     "display error when no groups are selected" in {

--- a/test/controllers/AddTeamMemberToGroupsControllerSpec.scala
+++ b/test/controllers/AddTeamMemberToGroupsControllerSpec.scala
@@ -111,16 +111,17 @@ class AddTeamMemberToGroupsControllerSpec extends BaseSpec {
       val form = html.select(Css.form)
       form.attr("action").shouldBe(submitUrl)
 
-      val fieldset = form.select("fieldset.govuk-fieldset")
-      fieldset.isEmpty shouldBe false // <-- fieldset needed for a11y
-
-      html.select("#groups-hint").text() shouldBe "Select all that apply"
+      val fieldset = form.select("fieldset.govuk-fieldset") // fieldset must exist and have a legend
+      fieldset.select(Css.legend).text() shouldBe "Which access groups would you like to add John Smith 1 to?"
+      fieldset.select("#groups-hint").text() shouldBe "Select all that apply"
       val checkboxes = fieldset.select(".govuk-checkboxes#groups input[name=groups[]]")
-      checkboxes.size() shouldBe 3
+      checkboxes.size() shouldBe 4
       val checkboxLabels = form.select("label.govuk-checkboxes__label")
       checkboxLabels.get(0).text() shouldBe "Group 3"
       checkboxLabels.get(1).text() shouldBe "Group 4"
       checkboxLabels.get(2).text() shouldBe "Group 5"
+      checkboxLabels.get(3).text() shouldBe "No access groups"
+      form.select("#__none__-item-hint").get(0).text() shouldBe "This will return you to the Manage account page"
       html.select(Css.linkStyledAsButton).text() shouldBe "Cancel"
       html.select(Css.linkStyledAsButton).hasClass("govuk-button--secondary")
       html.select(Css.linkStyledAsButton).hasClass("govuk-!-margin-right-3")
@@ -142,7 +143,6 @@ class AddTeamMemberToGroupsControllerSpec extends BaseSpec {
       expectGetGroupsForArn(arn)(groupSummaries)
       expectGetGroupSummariesForTeamMember(arn)(teamMember)(groupsAlreadyAssociatedToMember)
 
-
       //when
       val result = controller.showSelectGroupsForTeamMember(teamMember.id)(request)
 
@@ -154,12 +154,14 @@ class AddTeamMemberToGroupsControllerSpec extends BaseSpec {
       val form = html.select(Css.form)
       form.attr("action").shouldBe(submitUrl)
       val checkboxes = form.select(".govuk-checkboxes#groups input[name=groups[]]")
-      checkboxes.size() shouldBe 5
+      checkboxes.size() shouldBe 6
       val checkboxLabels = form.select("label.govuk-checkboxes__label")
       checkboxLabels.get(0).text() shouldBe "Group 1"
       checkboxLabels.get(1).text() shouldBe "Group 2"
       checkboxLabels.get(2).text() shouldBe "Group 3"
       checkboxLabels.get(4).text() shouldBe "Group 5"
+      checkboxLabels.get(5).text() shouldBe "No access groups"
+      form.select("#__none__-item-hint").get(0).text() shouldBe "This will return you to the Manage account page"
       html.select(Css.linkStyledAsButton).text() shouldBe "Cancel"
       html.select(Css.linkStyledAsButton).hasClass("govuk-button--secondary")
       html.select(Css.linkStyledAsButton).hasClass("govuk-!-margin-right-3")

--- a/test/forms/AddGroupsToClientFormSpec.scala
+++ b/test/forms/AddGroupsToClientFormSpec.scala
@@ -24,7 +24,7 @@ class AddGroupsToClientFormSpec extends AnyWordSpec
   with Matchers
   with GuiceOneAppPerSuite {
 
-  "Add Groups to Client form binding" should {
+  "AddGroupsToClientForm binding" should {
 
     "have have no errors when groups are present" in {
       val params = Map("groups[]" -> Seq("id1", "id2"))
@@ -35,6 +35,13 @@ class AddGroupsToClientFormSpec extends AnyWordSpec
       boundForm.value shouldBe Some(Seq("id1", "id2"))
     }
 
+    "be successful when only 'none of the above' is selected option" in {
+      val params = Map("groups[0]" -> AddGroupsToClientForm.NoneValue)
+      val boundForm = AddGroupsToClientForm.form().bind(params)
+      boundForm.hasErrors shouldBe false
+      boundForm.value shouldBe Some(Seq(AddGroupsToClientForm.NoneValue))
+    }
+
     "have errors when no groups selected" in {
       val params = Map("groups" -> List.empty)
       val boundForm = AddGroupsToClientForm
@@ -42,6 +49,15 @@ class AddGroupsToClientFormSpec extends AnyWordSpec
         .bindFromRequest(params)
       boundForm.hasErrors shouldBe true
       boundForm.errors.head.messages shouldBe Seq("error.select.groups.empty")
+    }
+
+    "have errors when groups and 'none of the above' are selected" in {
+      val params = Map("groups[]" -> Seq("id1", "id2", AddGroupsToClientForm.NoneValue))
+      val boundForm = AddGroupsToClientForm
+        .form()
+        .bindFromRequest(params)
+      boundForm.hasErrors shouldBe true
+      boundForm.errors.head.messages shouldBe Seq("unassigned.client.assign.invalid-selection.error")
     }
   }
 


### PR DESCRIPTION
- remove extra fieldset on page (already provided by govukCheckboxes component)
- add none of the above checkbox for adding 1 client/team member to groups pages
  - this behaves the same as what Daniele added for unassigned clients https://github.com/hmrc/agent-permissions-frontend/pull/406
- add missing "this is a problem" title from error summary

Should address outstanding issues on https://github.com/hmrc/accessibility-audits-external/issues/6380