### PR TITLE
APB-7669 Fix bug with group summary filtering

### DIFF
--- a/app/controllers/AddTeamMemberToGroupsController.scala
+++ b/app/controllers/AddTeamMemberToGroupsController.scala
@@ -53,7 +53,7 @@ class AddTeamMemberToGroupsController @Inject() (
           Ok(
             select_groups(
               membersGroups,
-              allGroups.diff(membersGroups),
+              allGroups.filterNot(group => membersGroups.exists(_.groupId == group.groupId)),
               tm,
               AddGroupsToClientForm.form()
             )
@@ -75,7 +75,7 @@ class AddTeamMemberToGroupsController @Inject() (
                 Ok(
                   select_groups(
                     membersGroups,
-                    allGroups.diff(membersGroups),
+                    allGroups.filterNot(group => membersGroups.exists(_.groupId == group.groupId)),
                     tm,
                     formErrors
                   )


### PR DESCRIPTION
The page currently retrieves “all groups” and “groups for team member”, then when deciding which checkboxes to show it attempts to filter out the groups the team member is already a part of. The bug here was due to the use of scala `.diff` function when comparing `GroupSummary` objects. The two calls returned slightly different objects - one contained the `clientCount` and another did not. This meant the diff check did not see them as the same group and so would render duplicates.

I’m not sure if this is due to stub data responses and/or some intended difference in the calls, but regardless I’ve changed the logic so it will instead just use the `groupId` of the `GroupSummary` for the filtering instead of comparing whole objects.

Here is a screenshot to show an example of how it looks after the fix. I created two groups, PPT and trusts, and a team member that belongs to the PPT group no longer gets a checkbox option for PPT.
![image](https://github.com/user-attachments/assets/01edc349-80d3-4c90-bee1-4acb6445abb5)
