### PR TITLE
APB-9879 fix JS not updating counter on single result pages

### DIFF
--- a/app/assets/javascripts/agent-permissions.js
+++ b/app/assets/javascripts/agent-permissions.js
@@ -4,10 +4,10 @@
     const selectedCountContainerEl = document.querySelector('#selected-count-text')
     const selectedCountMessageEl = document.querySelector('#selected-count-message')
     const checkBoxElements = document.querySelectorAll('input[type="checkbox"]:not(#checkboxes-all)')
-    if(selectAllEl && selectedCountEl && checkBoxElements.length) {
+    if(selectedCountContainerEl && checkBoxElements.length) {
         const syncSelectedState = () => selectAllEl.checked = [...checkBoxElements].every(option => option.checked)
         const countOnThisPage = () => [...checkBoxElements].filter(option => option.checked).length
-        const countOnOtherPages = Number(selectAllEl.dataset["selected"]) - countOnThisPage()
+        const countOnOtherPages = Number(selectedCountContainerEl.dataset["selected"]) - countOnThisPage()
         const updateTotalCount = () => {
             const newTotal = countOnThisPage() + countOnOtherPages
             selectedCountEl.textContent = "" + newTotal
@@ -15,13 +15,13 @@
                 selectedCountContainerEl.dataset["singular"] : selectedCountContainerEl.dataset["plural"]
         }
         checkBoxElements.forEach(option => option.addEventListener('click', () => {
-                syncSelectedState()
-                updateTotalCount()
-            }))
-        selectAllEl.addEventListener("click", event => {
+            selectAllEl && syncSelectedState()
+            updateTotalCount()
+        }))
+        selectAllEl && selectAllEl.addEventListener("click", event => {
             checkBoxElements.forEach(option => option.checked = event.target.checked)
             updateTotalCount()
         })
-        syncSelectedState()
+        selectAllEl && syncSelectedState()
     }
 })(document)

--- a/app/views/components/select_all_checkboxes.scala.html
+++ b/app/views/components/select_all_checkboxes.scala.html
@@ -16,11 +16,11 @@
 
 @this()
 
-@(totalSelected: Int)(implicit msgs: Messages)
+@()(implicit msgs: Messages)
 
 <div class="govuk-checkboxes govuk-checkboxes--small js-only" data-module="govuk-checkboxes">
     <div class="govuk-checkboxes__item">
-        <input type="checkbox" class="govuk-checkboxes__input" id="checkboxes-all" name="checkboxes-all" value="all" data-selected="@totalSelected">
+        <input type="checkbox" class="govuk-checkboxes__input" id="checkboxes-all" name="checkboxes-all" value="all">
         <label class="govuk-label govuk-checkboxes__label" for="checkboxes-all">@msgs("common.selectAll")</label>
     </div>
 </div>

--- a/app/views/partials/existing_group_selectable_clients_table_form.scala.html
+++ b/app/views/partials/existing_group_selectable_clients_table_form.scala.html
@@ -128,7 +128,7 @@
             }
 
             @if(totalResults > 1) {
-                @selectAllCheckbox(totalSelected)
+                @selectAllCheckbox()
             }
 
             @table(
@@ -149,6 +149,7 @@
         <p
         class="govuk-body js-only"
         id="selected-count-text"
+        data-selected="@totalSelected"
         data-singular="@{msgs("common.singular.clients.selected")}"
         data-plural="@{msgs("common.plural.clients.selected")}"
         >

--- a/app/views/partials/existing_group_selectable_clients_table_form.scala.html
+++ b/app/views/partials/existing_group_selectable_clients_table_form.scala.html
@@ -147,11 +147,12 @@
         }
 
         <p
-        class="govuk-body js-only"
-        id="selected-count-text"
-        data-selected="@totalSelected"
-        data-singular="@{msgs("common.singular.clients.selected")}"
-        data-plural="@{msgs("common.plural.clients.selected")}"
+            class="govuk-body js-only"
+            id="selected-count-text"
+            data-selected="@totalSelected"
+            data-singular="@{msgs("common.singular.clients.selected")}"
+            data-plural="@{msgs("common.plural.clients.selected")}"
+            aria-live="polite"
         >
             <strong id="selected-count">@totalSelected </strong>
             <span id="selected-count-message">

--- a/app/views/partials/existing_group_selectable_team_members_table_form.scala.html
+++ b/app/views/partials/existing_group_selectable_team_members_table_form.scala.html
@@ -94,7 +94,7 @@
                 }
 
                 @if(totalResults > 1) {
-                    @selectAllCheckbox(totalSelected)
+                    @selectAllCheckbox()
                 }
 
                 @table(
@@ -118,6 +118,7 @@
         <p
         class="govuk-body js-only"
         id="selected-count-text"
+        data-selected="@totalSelected"
         data-singular="@{msgs("common.singular.team-members.selected")}"
         data-plural="@{msgs("common.plural.team-members.selected")}"
         >

--- a/app/views/partials/existing_group_selectable_team_members_table_form.scala.html
+++ b/app/views/partials/existing_group_selectable_team_members_table_form.scala.html
@@ -116,11 +116,12 @@
         }
 
         <p
-        class="govuk-body js-only"
-        id="selected-count-text"
-        data-selected="@totalSelected"
-        data-singular="@{msgs("common.singular.team-members.selected")}"
-        data-plural="@{msgs("common.plural.team-members.selected")}"
+            class="govuk-body js-only"
+            id="selected-count-text"
+            data-selected="@totalSelected"
+            data-singular="@{msgs("common.singular.team-members.selected")}"
+            data-plural="@{msgs("common.plural.team-members.selected")}"
+            aria-live="polite"
         >
             @msgs("common.total.selected") <strong id="selected-count">@totalSelected </strong>
             <span id="selected-count-message">@msgs(s"common.${if(totalSelected == 1) "singular" else "plural"}.team-members.selected")</span>

--- a/app/views/partials/selectable_clients_table_form.scala.html
+++ b/app/views/partials/selectable_clients_table_form.scala.html
@@ -108,7 +108,7 @@
                 }
 
                 @if(totalResults > 1) {
-                  @selectAllCheckbox(totalSelected)
+                  @selectAllCheckbox()
                 }
 
                 @table(
@@ -134,6 +134,7 @@
         <p
             class="govuk-body js-only"
             id="selected-count-text"
+            data-selected="@totalSelected"
             data-singular="@{msgs("common.singular.clients.selected")}"
             data-plural="@{msgs("common.plural.clients.selected")}"
         >

--- a/app/views/partials/selectable_clients_table_form.scala.html
+++ b/app/views/partials/selectable_clients_table_form.scala.html
@@ -137,6 +137,7 @@
             data-selected="@totalSelected"
             data-singular="@{msgs("common.singular.clients.selected")}"
             data-plural="@{msgs("common.plural.clients.selected")}"
+            aria-live="polite"
         >
             <strong id="selected-count">@totalSelected </strong>
             <span id="selected-count-message">

--- a/app/views/partials/selectable_team_members_table_form.scala.html
+++ b/app/views/partials/selectable_team_members_table_form.scala.html
@@ -118,6 +118,7 @@
             data-selected="@totalSelected"
             data-singular="@{msgs("common.singular.team-members.selected")}"
             data-plural="@{msgs("common.plural.team-members.selected")}"
+            aria-live="polite"
         >
           @msgs("common.total.selected") <strong id="selected-count">@totalSelected </strong>
           <span id="selected-count-message">@msgs(s"common.${if(totalSelected == 1) "singular" else "plural"}.team-members.selected")</span>

--- a/app/views/partials/selectable_team_members_table_form.scala.html
+++ b/app/views/partials/selectable_team_members_table_form.scala.html
@@ -89,7 +89,7 @@
                 </legend>
 
                 @if(totalResults > 1) {
-                    @selectAllCheckbox(totalSelected)
+                    @selectAllCheckbox()
                 }
 
                 @table(
@@ -115,6 +115,7 @@
         <p
             class="govuk-body js-only"
             id="selected-count-text"
+            data-selected="@totalSelected"
             data-singular="@{msgs("common.singular.team-members.selected")}"
             data-plural="@{msgs("common.plural.team-members.selected")}"
         >


### PR DESCRIPTION
Addressed https://github.com/hmrc/accessibility-audits-external/issues/9815 by ensuring the counter scripts run when there is only one result and the Select All checkbox is not present on the page. The issue raises the question about whether it's appropriate to use this counter on a page with 1 result, which I would answer "yes" it is appropriate as the counter aggregates selections across multiple result page selections, so the starting position may not always be zero as in the example.

The "aria-live" attribute was added to the dynamic element to ensure counter updates are announced politely to screen reader users.

Screencast showing the solution in action:

[access-groups-counter-for-1-result.webm](https://github.com/user-attachments/assets/41d2834a-6294-4d73-83f2-9a1b1102e676)
